### PR TITLE
Add check for Java bin being on PATH

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2012-2015 Sauce Labs, Inc.
+Copyright 2012-2016 Sauce Labs, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/android.js
+++ b/lib/android.js
@@ -11,6 +11,21 @@ let checks = [];
 checks.push(new EnvVarAndPathCheck('ANDROID_HOME'));
 checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
 
+// Check that the PATH includes the jdk's bin directory
+class JavaOnPathCheck extends DoctorCheck {
+  async diagnose () {
+    let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
+    if (process.env.PATH.indexOf(javaHomeBin)) {
+      return nok('Bin directory of $JAVA_HOME is not set');
+    }
+    return ok('Bin directory for $JAVA_HOME is set');
+  }
+
+  fix () {
+    return `Add '$JAVA_HOME${path.sep}bin' to your PATH environment`;
+  }
+}
+
 // Check tools
 class AndroidToolCheck extends DoctorCheck {
   constructor (toolName, toolPath) {
@@ -41,6 +56,7 @@ checks.push(new AndroidToolCheck('android',
   path.join("tools", system.isWindows() ? 'android.bat' : 'android')));
 checks.push(new AndroidToolCheck('emulator',
   path.join("tools", system.isWindows() ? 'emulator.exe' : 'emulator')));
+checks.push(new JavaOnPathCheck());
 
-export { EnvVarAndPathCheck, AndroidToolCheck };
+export { EnvVarAndPathCheck, AndroidToolCheck, JavaOnPathCheck };
 export default checks;


### PR DESCRIPTION
On some systems installing `appium-selendroid-driver` fails because there is no Java on the PATH.

See https://github.com/appium/appium/issues/6464#issuecomment-234148294