### PR TITLE
Fixed checking jdk bin included in PATH

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -15,10 +15,10 @@ checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
 class JavaOnPathCheck extends DoctorCheck {
   async diagnose () {
     let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
-    if (process.env.PATH.indexOf(javaHomeBin)) {
-      return nok('Bin directory of $JAVA_HOME is not set');
+    if (process.env.PATH.indexOf(javaHomeBin) + 1) {
+      return ok('Bin directory of $JAVA_HOME is set');
     }
-    return ok('Bin directory for $JAVA_HOME is set');
+    return nok('Bin directory for $JAVA_HOME is not set');
   }
 
   fix () {


### PR DESCRIPTION
The condition checking for JAVA_HOME/bin was always returning true and throws an error.