### PR TITLE
Fix bin check when JAVA_HOME unset

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -14,9 +14,11 @@ checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
 // Check that the PATH includes the jdk's bin directory
 class JavaOnPathCheck extends DoctorCheck {
   async diagnose () {
-    let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
-    if (process.env.PATH.indexOf(javaHomeBin) + 1) {
-      return ok('Bin directory of $JAVA_HOME is set');
+    if (process.env.JAVA_HOME) {
+      let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
+      if (process.env.PATH.indexOf(javaHomeBin) + 1) {
+        return ok('Bin directory of $JAVA_HOME is set');
+      }
     }
     return nok('Bin directory for $JAVA_HOME is not set');
   }

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,6 +1,8 @@
 import 'colors';
 import _ from 'lodash';
 import log from './logger';
+import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
+
 
 class FixSkippedError extends Error {
 }
@@ -136,6 +138,7 @@ class Doctor {
   }
 
   async run () {
+    log.info(`Appium Doctor v.${version}`);
     await this.diagnose();
     if (await this.reportSuccess()) {
       return;


### PR DESCRIPTION
If there was no `JAVA_HOME`, the check for `$JAVA_HOME/bin` would throw an error and execution would stop.

Also add a little pre-amble with the version, so that bug reports can be more useful.