### PR TITLE
Add check for node version

### DIFF
--- a/bin/appium-doctor.js
+++ b/bin/appium-doctor.js
@@ -6,6 +6,7 @@ import { configureBinaryLog } from '../lib/utils';
 import { configure as configurePrompt } from '../lib/prompt';
 import { system } from 'appium-support';
 
+
 yargs
   .strict()
   .usage('Usage: $0 [options, defaults: --ios --android]')
@@ -32,7 +33,11 @@ yargs
     }
     return true;
   });
-let opts = yargs.argv;
+
+// make sure we use the general checks for every test
+let opts = Object.assign({
+  general: true,
+}, yargs.argv);
 
 configurePrompt(opts);
 configureBinaryLog(opts);

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -87,7 +87,7 @@ class Doctor {
       }
       log.info('###');
       log.info('');
-      log.info('Bye, run appium-doctor again when all manual fixes have been applied!');
+      log.info('Bye! Run appium-doctor again when all manual fixes have been applied!');
       log.info('');
       return true;
     } else {
@@ -129,10 +129,10 @@ class Doctor {
     }
     if (_.find(autoFixes, (f) => { return !f.fixed; })) {
       // a few issues remain.
-      log.info('Bye, a few issues remain, fix manually and/or rerun appium-doctor!');
+      log.info('Bye! A few issues remain, fix manually and/or rerun appium-doctor!');
     } else {
       // nothing left to fix.
-      log.info('Bye, all issues have been fixed!');
+      log.info('Bye! All issues have been fixed!');
     }
     log.info('');
   }

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
-import { Doctor } from './doctor.js';
+import { Doctor } from './doctor';
+import generalChecks from './general';
 import iosChecks from './ios';
 import androidChecks from './android';
 import devChecks from './dev';
 import demoChecks from './demo';
 
 
-let checks = { iosChecks, androidChecks, devChecks, demoChecks };
+let checks = {generalChecks, iosChecks, androidChecks, devChecks, demoChecks};
 
 let newDoctor = (opts) => {
   let doctor = new Doctor();

--- a/lib/general.js
+++ b/lib/general.js
@@ -1,0 +1,47 @@
+import { ok, nok } from './utils';
+import { exec } from 'teen_process';
+import { DoctorCheck } from './doctor';
+import NodeDetector from './node-detector';
+
+
+let checks = [];
+
+// Node Binary
+class NodeBinaryCheck extends DoctorCheck {
+  async diagnose () {
+    let nodePath = await NodeDetector.detect();
+    return nodePath ? ok(`The Node.js binary was found at: ${nodePath}`) :
+      nok('The Node.js binary was NOT found!');
+  }
+
+  fix () {
+    return `Manually setup Node.js.`;
+  }
+}
+checks.push(new NodeBinaryCheck());
+
+// Node version
+class NodeVersionCheck extends DoctorCheck {
+  async diagnose () {
+    let nodePath = await NodeDetector.detect();
+    if (!nodePath) {
+      return nok('Node is not installed, so no version to check!');
+    }
+    let {stdout} = await exec(nodePath, ['--version']);
+    let versionString = stdout.replace('v', '').trim();
+    let version = parseInt(versionString, 10);
+    if (Number.isNaN(version)) {
+      return nok(`Unable to find node version (version = '${versionString}')`);
+    }
+    return version >= 4 ? ok(`Node version is ${versionString}`) :
+      nok('Node version should be at least 4!');
+  }
+
+  fix () {
+    return `Manually upgrade Node.js.`;
+  }
+}
+checks.push(new NodeVersionCheck());
+
+export { NodeBinaryCheck, NodeVersionCheck };
+export default checks;

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -3,7 +3,6 @@ import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
 import { DoctorCheck, FixSkippedError } from './doctor';
 import log from './logger';
-import NodeDetector from './node-detector';
 import CarthageDetector from './carthage-detector';
 import { fixIt } from './prompt';
 import EnvVarAndPathCheck from './env';
@@ -139,20 +138,6 @@ class AuthorizationDbCheck extends DoctorCheck {
 }
 checks.push(new AuthorizationDbCheck());
 
-// Node Binary
-class NodeBinaryCheck extends DoctorCheck {
-  async diagnose () {
-    let nodePath = await NodeDetector.detect();
-    return nodePath ? ok(`The Node.js binary was found at: ${nodePath}`) :
-      nok('The Node.js binary was NOT found!');
-  }
-
-  fix () {
-    return `Manually setup Node.js.`;
-  }
-}
-checks.push(new NodeBinaryCheck());
-
 // Check for Carthage (for WDA)
 class CarthageCheck extends DoctorCheck {
   async diagnose () {
@@ -171,5 +156,5 @@ checks.push(new CarthageCheck());
 checks.push(new EnvVarAndPathCheck('HOME'));
 
 export { fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
-         AuthorizationDbCheck, NodeBinaryCheck, CarthageCheck };
+         AuthorizationDbCheck, CarthageCheck };
 export default checks;

--- a/lib/node-detector.js
+++ b/lib/node-detector.js
@@ -29,7 +29,7 @@ class NodeDetector {
     } catch (ign) {}
     let nodePath = stdout.replace("\n", "");
     if (await fs.exists(nodePath)) {
-      log.debug("Node binary found using which command at: " + nodePath);
+      log.debug(`Node binary found using which command at: ${nodePath}`);
       return nodePath;
     } else {
       log.debug('Node binary not found using the which command.');
@@ -67,7 +67,7 @@ class NodeDetector {
   static async retrieveUsingAppiumConfigFile () {
     let jsonobj;
     try {
-      var appiumConfigPath = path.resolve(__dirname, '../..', '.appiumconfig.json');
+      var appiumConfigPath = path.resolve(__dirname, '..', '..', '.appiumconfig.json');
       if (await fs.exists(appiumConfigPath)) {
         jsonobj = JSON.parse(await fs.readFile(appiumConfigPath, 'utf8'));
       }

--- a/test/doctor-specs.js
+++ b/test/doctor-specs.js
@@ -94,7 +94,7 @@ describe('doctor', () => {
         'warn: - Manual fix for 3 is do something.',
         'info: ###',
         'info: ',
-        'info: Bye, run appium-doctor again when all manual fixes have been applied!',
+        'info: Bye! Run appium-doctor again when all manual fixes have been applied!',
         'info: '
       ].join('\n'));
     });
@@ -195,7 +195,7 @@ describe('doctor', () => {
         'info: ',
         'info: Autofix log go there.',
         'info: ',
-        'info: Bye, all issues have been fixed!',
+        'info: Bye! All issues have been fixed!',
         'info: ',
       ].join('\n'));
     });
@@ -226,7 +226,7 @@ describe('doctor', () => {
         'info: ',
         'warn: failed, Autofix log go there.',
         'info: ',
-        'info: Bye, a few issues remain, fix manually and/or rerun appium-doctor!',
+        'info: Bye! A few issues remain, fix manually and/or rerun appium-doctor!',
         'info: ',
       ].join('\n'));
     });

--- a/test/general-specs.js
+++ b/test/general-specs.js
@@ -1,0 +1,78 @@
+// transpile:mocha
+
+import { NodeBinaryCheck, NodeVersionCheck } from '../lib/general';
+import * as tp from 'teen_process';
+import NodeDetector from '../lib/node-detector';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { withMocks, verify } from 'appium-test-support';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+let P = Promise;
+
+describe('general', () => {
+  describe('NodeBinaryCheck', withMocks({NodeDetector}, (mocks) => {
+    let check = new NodeBinaryCheck();
+    it('autofix', () => {
+      check.autofix.should.not.be.ok;
+    });
+    it('diagnose - success', async () => {
+      mocks.NodeDetector.expects('detect').once().returns(P.resolve('/a/b/c/d'));
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        message: 'The Node.js binary was found at: /a/b/c/d'
+      });
+      verify(mocks);
+    });
+    it('diagnose - failure', async () => {
+      mocks.NodeDetector.expects('detect').once().returns(P.resolve(null));
+      (await check.diagnose()).should.deep.equal({
+        ok: false,
+        message: 'The Node.js binary was NOT found!'
+      });
+      verify(mocks);
+    });
+    it('fix', async () => {
+      (await check.fix()).should.equal('Manually setup Node.js.');
+    });
+  }));
+
+  describe('NodeVersionCheck', withMocks({NodeDetector, tp}, (mocks) => {
+    let check = new NodeVersionCheck();
+    it('autofix', () => {
+      check.autofix.should.not.be.ok;
+    });
+    it('diagnose - success', async () => {
+      mocks.NodeDetector.expects('detect').once().returns(P.resolve('/a/b/c/d'));
+      mocks.tp.expects('exec').once().returns(P.resolve({stdout: 'v4.5.6', stderr: ''}));
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        message: 'Node version is 4.5.6'
+      });
+      verify(mocks);
+    });
+    it('diagnose - failure - insufficient version', async () => {
+      mocks.NodeDetector.expects('detect').once().returns(P.resolve('/a/b/c/d'));
+      mocks.tp.expects('exec').once().returns(P.resolve({stdout: 'v0.12.18', stderr: ''}));
+      (await check.diagnose()).should.deep.equal({
+        ok: false,
+        message: 'Node version should be at least 4!'
+      });
+      verify(mocks);
+    });
+    it('diagnose - failure - bad output', async () => {
+      mocks.NodeDetector.expects('detect').once().returns(P.resolve('/a/b/c/d'));
+      mocks.tp.expects('exec').once().returns(P.resolve({stdout: 'blahblahblah', stderr: ''}));
+      (await check.diagnose()).should.deep.equal({
+        ok: false,
+        message: `Unable to find node version (version = 'blahblahblah')`
+      });
+      verify(mocks);
+    });
+    it('fix', async () => {
+      (await check.fix()).should.equal('Manually upgrade Node.js.');
+    });
+  }));
+});

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -1,12 +1,11 @@
 // transpile:mocha
 
 import { fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
-  AuthorizationDbCheck, NodeBinaryCheck, CarthageCheck } from '../lib/ios';
+  AuthorizationDbCheck, CarthageCheck } from '../lib/ios';
 import { fs, system } from 'appium-support';
 import * as utils from '../lib/utils';
 import * as tp from 'teen_process';
 import * as prompter from '../lib/prompt';
-import NodeDetector from '../lib/node-detector';
 import CarthageDetector from '../lib/carthage-detector';
 import FixSkippedError from '../lib/doctor';
 import log from '../lib/logger';
@@ -224,31 +223,6 @@ describe('ios', () => {
       mocks.fixes.expects('authorizeIosFix').once();
       await check.fix();
       verify(mocks);
-    });
-  }));
-  describe('NodeBinaryCheck', withMocks({NodeDetector}, (mocks) => {
-    let check = new NodeBinaryCheck();
-    it('autofix', () => {
-      check.autofix.should.not.be.ok;
-    });
-    it('diagnose - success', async () => {
-      mocks.NodeDetector.expects('detect').once().returns(P.resolve('/a/b/c/d'));
-      (await check.diagnose()).should.deep.equal({
-        ok: true,
-        message: 'The Node.js binary was found at: /a/b/c/d'
-      });
-      verify(mocks);
-    });
-    it('diagnose - failure', async () => {
-      mocks.NodeDetector.expects('detect').once().returns(P.resolve(null));
-      (await check.diagnose()).should.deep.equal({
-        ok: false,
-        message: 'The Node.js binary was NOT found!'
-      });
-      verify(mocks);
-    });
-    it('fix', async () => {
-      (await check.fix()).should.equal('Manually setup Node.js.');
     });
   }));
   describe('CarthageCheck', withMocks({CarthageDetector}, (mocks) => {


### PR DESCRIPTION
Add a check to make sure the node version is correct. Also move the node checks (existence and version) into a general check, so that it is checked for both Android and iOS.