### PR TITLE
Added %JAVA_HOME% for diagnostics on Windows.

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -7,7 +7,7 @@ import EnvVarAndPathCheck from './env';
 
 let checks = [];
 
-let javaHome = process.platform === 'win32' ? '%JAVA_HOME%' : '$JAVA_HOME';
+let javaHome = system.isWindows() ? '%JAVA_HOME%' : '$JAVA_HOME';
 
 checks.push(new EnvVarAndPathCheck('ANDROID_HOME'));
 checks.push(new EnvVarAndPathCheck('JAVA_HOME'));

--- a/lib/android.js
+++ b/lib/android.js
@@ -7,6 +7,7 @@ import EnvVarAndPathCheck from './env';
 
 let checks = [];
 
+let javaHome = process.platform === 'win32' ? '%JAVA_HOME%' : '$JAVA_HOME';
 
 checks.push(new EnvVarAndPathCheck('ANDROID_HOME'));
 checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
@@ -17,14 +18,14 @@ class JavaOnPathCheck extends DoctorCheck {
     if (process.env.JAVA_HOME) {
       let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
       if (process.env.PATH.indexOf(javaHomeBin) + 1) {
-        return ok('Bin directory of $JAVA_HOME is set');
+        return ok(`Bin directory of ${javaHome} is set`);
       }
     }
-    return nok('Bin directory for $JAVA_HOME is not set');
+    return nok(`Bin directory for ${javaHome} is not set`);
   }
 
   fix () {
-    return `Add '$JAVA_HOME${path.sep}bin' to your PATH environment`;
+    return `Add '${javaHome}${path.sep}bin' to your PATH environment`;
   }
 }
 


### PR DESCRIPTION
Currently on Windows, if you run `appium-doctor`, the diagnostics will contain `$JAVA_HOME` as its verbiage. This only applies to macOS and Linux based OSes.

This PR remedies that issue by detecting which OS `appium-doctor` is running on and will use the correct `JAVA_HOME` string.

Also, I've tested this PR on both macOS and Windows and no new issues appeared.