### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"
 script:
   - gulp eslint && gulp once
 after_success:

--- a/lib/android.js
+++ b/lib/android.js
@@ -14,7 +14,7 @@ checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
 
 // Check that the PATH includes the jdk's bin directory
 class JavaOnPathCheck extends DoctorCheck {
-  async diagnose () {
+  async diagnose () { // eslint-disable-line require-await
     if (process.env.JAVA_HOME) {
       let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
       if (process.env.PATH.indexOf(javaHomeBin) + 1) {
@@ -43,7 +43,7 @@ class AndroidToolCheck extends DoctorCheck {
     }
     let fullPath = path.resolve(process.env.ANDROID_HOME, this.toolPath);
     return await fs.exists(fullPath) ? ok(`${this.toolName} exists at: ${fullPath}`) :
-      nok(`${this.toolName} could NOT be found at \'${fullPath}\'!`);
+      nok(`${this.toolName} could NOT be found at '${fullPath}'!`);
   }
 
   fix () {

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -18,14 +18,14 @@ class DirCheck extends DoctorCheck {
 
   async diagnose () {
     if (!await fs.exists(this.path)) {
-      return nok(`Could NOT find directory at \'${this.path}\'!`);
+      return nok(`Could NOT find directory at '${this.path}'!`);
     }
     let stats = await fs.lstat(this.path);
     return stats.isDirectory() ?
-      ok(`Found directory at: ${this.path}`) : nok(`\'${this.path}\' is NOT a directory!`);
+      ok(`Found directory at: ${this.path}`) : nok(`'${this.path}' is NOT a directory!`);
   }
 
-  async fix () {
+  async fix () { // eslint-disable-line require-await
     return `Manually create a directory at: ${this.path}`;
   }
 }
@@ -41,7 +41,7 @@ class FileCheck extends DoctorCheck {
 
   async diagnose () {
     return await fs.exists(this.path) ?
-      ok(`Found file at: ${this.path}`) : nok(`Could NOT find file at \'${this.path}\'!`);
+      ok(`Found file at: ${this.path}`) : nok(`Could NOT find file at '${this.path}'!`);
   }
 
   async fix () {

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -18,7 +18,7 @@ class BinaryIsInPathCheck extends DoctorCheck {
     let resolvedPath;
     try {
       let executable = system.isWindows() ? 'where' : 'which';
-      let {stdout} =  await exec(executable, [this.binary]);
+      let {stdout} = await exec(executable, [this.binary]);
       if (stdout.match(/not found/gi)) {
         throw new Error('Not Found');
       }
@@ -52,7 +52,7 @@ class AndroidSdkExists extends DoctorCheck {
     }
     let sdkPath = path.resolve(process.env.ANDROID_HOME, path.join("platforms", this.sdk));
     return await fs.exists(sdkPath) ? ok(`${this.sdk} was found at: ${sdkPath}`) :
-      nok(`${this.sdk} could NOT be found at \'${sdkPath}\'!`);
+      nok(`${this.sdk} could NOT be found at '${sdkPath}'!`);
   }
 
   fix () {

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -8,7 +8,7 @@ class FixSkippedError extends Error {
 }
 
 class DoctorCheck {
-  constructor (opts={}) {
+  constructor (opts = {}) {
     this.autofix = !!opts.autofix;
   }
 
@@ -62,7 +62,7 @@ class Doctor {
     log.info('');
   }
 
-  async reportSuccess () {
+  async reportSuccess () { // eslint-disable-line require-await
     if (this.toFix.length === 0) {
       log.info('Everything looks good, bye!');
       log.info('');
@@ -74,7 +74,7 @@ class Doctor {
 
   async reportManualFixes () {
     let manualFixes = _.filter(this.toFix, (f) => {return !f.check.autofix;});
-    if (manualFixes.length >0) {
+    if (manualFixes.length > 0) {
       log.info('### Manual Fixes Needed ###');
       log.info('The configuration cannot be automatically fixed, please do the following first:');
       // for manual fixes, the fix method always return a string

--- a/lib/env.js
+++ b/lib/env.js
@@ -16,7 +16,7 @@ class EnvVarAndPathCheck extends DoctorCheck {
       return nok(`${this.varName} is NOT set!`);
     }
     return await fs.exists(varValue) ? ok(`${this.varName} is set to: ${varValue}`) :
-       nok(`${this.varName} is set to \'${varValue}\' but this is NOT a valid path!`);
+      nok(`${this.varName} is set to '${varValue}' but this is NOT a valid path!`);
   }
 
   fix () {

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -1,4 +1,4 @@
-import { ok, nok, authorize } from './utils';
+import { ok, nok, authorizeIos } from './utils'; // eslint-disable-line
 import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
 import { DoctorCheck, FixSkippedError } from './doctor';
@@ -22,10 +22,10 @@ class XcodeCheck extends DoctorCheck {
       return nok('Xcode is NOT installed!');
     }
     return xcodePath && await fs.exists(xcodePath) ? ok(`Xcode is installed at: ${xcodePath}`) :
-      nok(`Xcode cannot be found at \'${xcodePath}\'!`);
+      nok(`Xcode cannot be found at '${xcodePath}'!`);
   }
 
-  async fix () {
+  async fix () { // eslint-disable-line require-await
     return 'Manually install Xcode.';
   }
 }
@@ -70,7 +70,7 @@ fixes.authorizeIosFix = async function () {
   log.info(`The authorize iOS script need to be run.`);
   let yesno = await fixIt();
   if (yesno === 'yes') {
-    await authorize();
+    await authorizeIos();
   } else {
     log.info('Skipping you will need to run the authorize iOS manually.');
     throw new FixSkippedError();
@@ -122,7 +122,7 @@ class AuthorizationDbCheck extends DoctorCheck {
           log.debug(err);
           return nok(errMess);
         }
-        let rg =/<key>system.privilege.taskport<\/key>\s*\n\s*<dict>\n\s*<key>allow-root<\/key>\n\s*(<true\/>)/;
+        let rg = /<key>system.privilege.taskport<\/key>\s*\n\s*<dict>\n\s*<key>allow-root<\/key>\n\s*(<true\/>)/;
         return data && data.match(rg) ? ok(successMess) : nok(errMess);
       } else {
         log.debug(err);
@@ -130,7 +130,7 @@ class AuthorizationDbCheck extends DoctorCheck {
       }
     }
     return stdout && (stdout.match(/is-developer/) || stdout.match(/allow/)) ?
-       ok(successMess) : nok(errMess);
+      ok(successMess) : nok(errMess);
   }
   async fix () {
     return await fixes.authorizeIosFix();
@@ -142,11 +142,12 @@ checks.push(new AuthorizationDbCheck());
 class CarthageCheck extends DoctorCheck {
   async diagnose () {
     let carthagePath = await CarthageDetector.detect();
-    return carthagePath ? ok(`Carthage was found at: ${carthagePath}`) :
-                          nok(`Carthage was NOT found!`);
+    return carthagePath
+      ? ok(`Carthage was found at: ${carthagePath}`)
+      : nok(`Carthage was NOT found!`);
   }
 
-  async fix () {
+  async fix () { // eslint-disable-line require-await
     return 'Please install Carthage. Visit https://github.com/Carthage' +
            '/Carthage#installing-carthage for more information.';
   }
@@ -155,6 +156,8 @@ checks.push(new CarthageCheck());
 
 checks.push(new EnvVarAndPathCheck('HOME'));
 
-export { fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
-         AuthorizationDbCheck, CarthageCheck };
+export {
+  fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
+  AuthorizationDbCheck, CarthageCheck,
+};
 export default checks;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,13 +4,17 @@ import _inquirer from 'inquirer';
 import log from '../lib/logger';
 import authorize from 'authorize-ios';
 
-let pkgRoot = process.env.NO_PRECOMPILE ?
+
+// rename to make more sense
+const authorizeIos = authorize;
+
+const pkgRoot = process.env.NO_PRECOMPILE ?
   path.resolve(__dirname, '..') : path.resolve(__dirname, '..', '..');
 
-let ok = (message) => { return {ok: true, message}; };
-let nok = (message) => { return {ok: false, message}; };
+const ok = (message) => { return {ok: true, message}; };
+const nok = (message) => { return {ok: false, message}; };
 
-let inquirer = {
+const inquirer = {
   prompt: B.promisify(function (question, cb) { // eslint-disable-line promise/prefer-await-to-callbacks
     _inquirer.prompt(question, function (resp) { cb(null, resp); }); // eslint-disable-line promise/prefer-await-to-callbacks
   })
@@ -26,4 +30,4 @@ function configureBinaryLog (opts) {
   log.level = opts.debug ? 'debug' : 'info';
 }
 
-export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorize };
+export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorizeIos, };

--- a/package.json
+++ b/package.json
@@ -24,10 +24,19 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "appium-doctor.js",
+    "index.js",
+    "lib",
+    "bin",
+    "build/appium-doctor.js",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
     "authorize-ios": "^1.0.3",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "colors": "^1.1.2",
     "inquirer": "^6.1.0",
@@ -38,7 +47,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
@@ -51,31 +60,21 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
     "appium-test-support": "^1.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.9.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "pre-commit": "^1.1.3"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/dev-specs.js
+++ b/test/dev-specs.js
@@ -31,7 +31,7 @@ describe('dev', function () {
     it('diagnose - failure - not in path ', async function () {
       process.env.PATH = '/a/b/c/d;/e/f/g/h';
       mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: 'mvn not found\n', stderr:''}));
+        B.resolve({stdout: 'mvn not found\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
         ok: false,
         message: 'mvn is MISSING in PATH!'

--- a/test/doctor-specs.js
+++ b/test/doctor-specs.js
@@ -76,7 +76,7 @@ describe('doctor', function () {
         {error: 'Oh no this also need to be manually fixed.', check: new DoctorCheck()},
         {error: 'Oh no this also need to be manually fixed.', check: new DoctorCheck()},
       ];
-      for (let i=0; i<doctor.toFix.length; i++) {
+      for (let i = 0; i < doctor.toFix.length; i++) {
         let m = S.sandbox.mock(doctor.toFix[i].check);
         if (doctor.toFix[i].check.autofix) {
           m.expects('fix').never();
@@ -105,7 +105,7 @@ describe('doctor', function () {
     });
   }));
 
-  describe('runAutoFix',  withSandbox({}, (S) => {
+  describe('runAutoFix', withSandbox({}, (S) => {
     let doctor = new Doctor();
     let fix = {
       error: 'Something wrong!',
@@ -173,7 +173,7 @@ describe('doctor', function () {
     });
   }));
 
-  describe('runAutoFixes',  withSandbox({}, (S) => {
+  describe('runAutoFixes', withSandbox({}, (S) => {
     let doctor = new Doctor();
     it('success', async function () {
       let logStub = stubLog(S.sandbox, log, {stripColors: true});
@@ -232,7 +232,7 @@ describe('doctor', function () {
     });
   }));
 
-  describe('run',  withSandbox({}, (S) => {
+  describe('run', withSandbox({}, (S) => {
     let doctor = new Doctor();
     it('should work', async function () {
       try {

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -1,7 +1,7 @@
 // transpile:mocha
 
 import { fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
-  AuthorizationDbCheck, CarthageCheck } from '../lib/ios';
+         AuthorizationDbCheck, CarthageCheck } from '../lib/ios';
 import { fs, system } from 'appium-support';
 import * as utils from '../lib/utils';
 import * as tp from 'teen_process';
@@ -117,7 +117,7 @@ describe('ios', function () {
   describe('authorizeIosFix', withSandbox({mocks: {utils, prompter}}, (S) => {
     it('fix - yes', async function () {
       let logStub = stubLog(S.sandbox, log, {stripColors: true});
-      S.mocks.utils.expects('authorize').once();
+      S.mocks.utils.expects('authorizeIos').once();
       S.mocks.prompter.expects('fixIt').once().returns(B.resolve('yes'));
       await fixes.authorizeIosFix();
       S.verify();
@@ -127,7 +127,7 @@ describe('ios', function () {
     });
     it('fix - no', async function () {
       let logStub = stubLog(S.sandbox, log, {stripColors: true});
-      S.mocks.utils.expects('authorize').never();
+      S.mocks.utils.expects('authorizeIos').never();
       S.mocks.prompter.expects('fixIt').once().returns(B.resolve('no'));
       await fixes.authorizeIosFix().should.be.rejectedWith(FixSkippedError);
       S.verify();


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.