### PR TITLE
fix railing error in checking Xcode CLI installation for macOS 10.11+

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -39,16 +39,14 @@ class XcodeCmdLineToolsCheck extends DoctorCheck {
 
   async diagnose () {
     const errMess = 'Xcode Command Line Tools are NOT installed!';
-    let pkgName = await system.macOsxVersion() === '10.8' ? 'com.apple.pkg.DeveloperToolsCLI' : 'com.apple.pkg.CLTools_Executables';
-    let stdout;
     try {
-      stdout = (await exec('pkgutil', [`--pkg-info=${pkgName}`])).stdout;
+      // https://stackoverflow.com/questions/15371925/how-to-check-if-command-line-tools-is-installed
+      const stdout = (await exec('xcode-select', ['-p'])).stdout;
+      return ok(`Xcode Command Line Tools are installed in: ${stdout}`);
     } catch (err) {
       log.debug(err);
       return nok(errMess);
     }
-    return stdout.match(/install-time/) ? ok('Xcode Command Line Tools are installed.') :
-      nok(errMess);
   }
 
   async fix () {

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -62,17 +62,15 @@ describe('ios', function () {
       check.autofix.should.be.ok;
     });
     it('diagnose - success', async function () {
-      S.mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.10'));
       S.mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: '1234 install-time\n', stderr: ''}));
+        B.resolve({stdout: '/Applications/Xcode.app/Contents/Developer\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
         ok: true,
-        message: 'Xcode Command Line Tools are installed.'
+        message: 'Xcode Command Line Tools are installed in: /Applications/Xcode.app/Contents/Developer\n'
       });
       S.verify();
     });
     it('diagnose - failure - pkgutil crash', async function () {
-      S.mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.10'));
       S.mocks.tp.expects('exec').once().throws(new Error('Something wrong!'));
       (await check.diagnose()).should.deep.equal({
         ok: false,
@@ -80,10 +78,8 @@ describe('ios', function () {
       });
       S.verify();
     });
-    it('diagnose - failure - no install time', async function () {
-      S.mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.10'));
-      S.mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: '1234 abcd\n', stderr: ''}));
+    it('diagnose - failure - xcode-select -p returns status 2', async function () {
+      S.mocks.tp.expects('exec').once().throws(new Error());
       (await check.diagnose()).should.deep.equal({
         ok: false,
         message: 'Xcode Command Line Tools are NOT installed!'


### PR DESCRIPTION
AS below, I faced `Xcode Command Line Tools are NOT installed!` error evern I had it. It had never succeeded even I selected `yes` and re-ran the doctor.

According to https://stackoverflow.com/questions/15371925/how-to-check-if-command-line-tools-is-installed and my local check, current logic no longer works for recent macOS. Instead, we must call `xcode-select -p`, simply. If the command exists error status, we should install xcode CLI.

```bash
$ appium-doctor
info AppiumDoctor Appium Doctor v.1.6.0
info AppiumDoctor ### Diagnostic starting ###
info AppiumDoctor  ✔ The Node.js binary was found at: /Users/kazuaki/.nodebrew/current/bin/node
info AppiumDoctor  ✔ Node version is 10.11.0
info AppiumDoctor  ✔ Xcode is installed at: /Applications/Xcode.app/Contents/Developer
WARN AppiumDoctor  ✖ Xcode Command Line Tools are NOT installed!
info AppiumDoctor  ✔ DevToolsSecurity is enabled.
info AppiumDoctor  ✔ The Authorization DB is set up properly.
info AppiumDoctor  ✔ Carthage was found at: /usr/local/bin/carthage
info AppiumDoctor  ✔ HOME is set to: /Users/kazuaki
info AppiumDoctor  ✔ ANDROID_HOME is set to: /Users/kazuaki/Library/Android/sdk
info AppiumDoctor  ✔ JAVA_HOME is set to: /Library/Java/JavaVirtualMachines/jdk1.8.0_121.jdk/Contents/Home
info AppiumDoctor  ✔ adb exists at: /Users/kazuaki/Library/Android/sdk/platform-tools/adb
info AppiumDoctor  ✔ android exists at: /Users/kazuaki/Library/Android/sdk/tools/android
info AppiumDoctor  ✔ emulator exists at: /Users/kazuaki/Library/Android/sdk/tools/emulator
info AppiumDoctor  ✔ Bin directory of $JAVA_HOME is set
info AppiumDoctor ### Diagnostic completed, one fix needed. ###
info AppiumDoctor
info AppiumDoctor ### Fixing:  ✖ Xcode Command Line Tools are NOT installed! ###
info AppiumDoctor The following command need be executed: xcode-select --install
? Fix it: yes
```

We can remove macOS version check since even Xcode8, it was deprecated, requires 10.11.4.