### PR TITLE
use split instead of replace for windows case

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -2,7 +2,6 @@ import { DoctorCheck } from './doctor';
 import { ok, nok, resolveExecutablePath } from './utils';
 import { fs, system } from 'appium-support';
 import path from 'path';
-import _ from 'lodash';
 
 let checks = [];
 
@@ -15,12 +14,11 @@ class BinaryIsInPathCheck extends DoctorCheck {
 
   async diagnose () {
     const resolvedPath = await resolveExecutablePath(this.binary);
-    if (_.isNull(resolvedPath)) {
+    if (!resolvedPath) {
       return nok(`${this.binary} is MISSING in PATH!`);
     }
 
-    return await fs.exists(resolvedPath) ? ok(`${this.binary} was found at ${resolvedPath}`) :
-      nok(`${this.binary} was found in PATH at '${resolvedPath}', but this is NOT a valid path!`);
+    return ok(`${this.binary} was found at ${resolvedPath}`);
   }
 
   fix () {

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -1,9 +1,8 @@
-import { exec } from 'teen_process';
 import { DoctorCheck } from './doctor';
-import { ok, nok } from './utils';
+import { ok, nok, resolveExecutablePath } from './utils';
 import { fs, system } from 'appium-support';
 import path from 'path';
-import { EOL } from 'os';
+import _ from 'lodash';
 
 let checks = [];
 
@@ -15,17 +14,11 @@ class BinaryIsInPathCheck extends DoctorCheck {
   }
 
   async diagnose () {
-    let resolvedPath;
-    try {
-      let executable = system.isWindows() ? 'where' : 'which';
-      let {stdout} = await exec(executable, [this.binary]);
-      if (stdout.match(/not found/gi)) {
-        throw new Error('Not Found');
-      }
-      resolvedPath = system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
-    } catch (err) {
+    const resolvedPath = await resolveExecutablePath(this.binary);
+    if (_.isNull(resolvedPath)) {
       return nok(`${this.binary} is MISSING in PATH!`);
     }
+
     return await fs.exists(resolvedPath) ? ok(`${this.binary} was found at ${resolvedPath}`) :
       nok(`${this.binary} was found in PATH at '${resolvedPath}', but this is NOT a valid path!`);
   }

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -15,7 +15,7 @@ class BinaryIsInPathCheck extends DoctorCheck {
   async diagnose () {
     const resolvedPath = await resolveExecutablePath(this.binary);
     if (!resolvedPath) {
-      return nok(`${this.binary} is MISSING in PATH!`);
+      return nok(`${this.binary} is MISSING in PATH: ${process.env.PATH}`);
     }
 
     return ok(`${this.binary} was found at ${resolvedPath}`);

--- a/lib/node-detector.js
+++ b/lib/node-detector.js
@@ -27,7 +27,7 @@ class NodeDetector {
     const nodePath = await resolveExecutablePath('node');
 
     if (!nodePath) {
-      log.debug(`Node binary not found.`);
+      log.debug(`Node binary not found in PATH: ${process.env.PATH}`);
       return null;
     }
 

--- a/lib/node-detector.js
+++ b/lib/node-detector.js
@@ -36,7 +36,8 @@ class NodeDetector {
       log.debug(err);
       return null;
     }
-    let nodePath = stdout.replace(/[\n\r]/g, "");
+    // stdout can be multiple lines in windows environment. Read https://github.com/appium/appium-doctor/issues/33
+    let nodePath = stdout.split(/\r?\n/)[0];
     if (await fs.exists(nodePath)) {
       log.debug(`Node binary found using ${cmd} command at: ${nodePath}`);
       return nodePath;
@@ -71,7 +72,7 @@ class NodeDetector {
       log.debug(err);
       return null;
     }
-    let nodePath = stdout.replace("\n", "");
+    let nodePath = stdout.split(/\r?\n/)[0];
     if (await fs.exists(nodePath)) {
       log.debug(`Node binary found using AppleScript at: ${nodePath}`);
       return nodePath;

--- a/lib/node-detector.js
+++ b/lib/node-detector.js
@@ -2,7 +2,6 @@ import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
 import log from './logger';
 import path from 'path';
-import _ from 'lodash';
 import { resolveExecutablePath } from './utils';
 
 const NODE_COMMON_PATHS = [
@@ -27,17 +26,13 @@ class NodeDetector {
   static async retrieveUsingSystemCall () {
     const nodePath = await resolveExecutablePath('node');
 
-    if (_.isNull(nodePath)) {
-      return null;
-    }
-
-    if (await fs.exists(nodePath)) {
-      log.debug(`Node binary found at: ${nodePath}`);
-      return nodePath;
-    } else {
+    if (!nodePath) {
       log.debug(`Node binary not found.`);
       return null;
     }
+
+    log.debug(`Node binary found at: ${nodePath}`);
+    return nodePath;
   }
 
   static async retrieveUsingAppleScript () {

--- a/lib/node-detector.js
+++ b/lib/node-detector.js
@@ -2,6 +2,8 @@ import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
 import log from './logger';
 import path from 'path';
+import _ from 'lodash';
+import { resolveExecutablePath } from './utils';
 
 const NODE_COMMON_PATHS = [
   process.env.NODE_BIN,
@@ -23,26 +25,17 @@ class NodeDetector {
   }
 
   static async retrieveUsingSystemCall () {
-    let stdout;
-    let cmd = 'which';
+    const nodePath = await resolveExecutablePath('node');
 
-    if (system.isWindows()) {
-      cmd = 'where';
-    }
-
-    try {
-      stdout = (await exec(cmd, ['node'])).stdout;
-    } catch (err) {
-      log.debug(err);
+    if (_.isNull(nodePath)) {
       return null;
     }
-    // stdout can be multiple lines in windows environment. Read https://github.com/appium/appium-doctor/issues/33
-    let nodePath = stdout.split(/\r?\n/)[0];
+
     if (await fs.exists(nodePath)) {
-      log.debug(`Node binary found using ${cmd} command at: ${nodePath}`);
+      log.debug(`Node binary found at: ${nodePath}`);
       return nodePath;
     } else {
-      log.debug(`Node binary not found using the ${cmd} command.`);
+      log.debug(`Node binary not found.`);
       return null;
     }
   }
@@ -72,7 +65,7 @@ class NodeDetector {
       log.debug(err);
       return null;
     }
-    let nodePath = stdout.split(/\r?\n/)[0];
+    let nodePath = stdout.replace("\n", "");
     if (await fs.exists(nodePath)) {
       log.debug(`Node binary found using AppleScript at: ${nodePath}`);
       return nodePath;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,6 @@ import authorize from 'authorize-ios';
 import { EOL } from 'os';
 import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
-import _ from 'lodash';
 
 // rename to make more sense
 const authorizeIos = authorize;
@@ -43,17 +42,17 @@ async function resolveExecutablePath (cmd) {
   const executable = system.isWindows() ? 'where' : 'which';
   let stdout;
   try {
-    stdout = (await exec(executable, [cmd])).stdout;
-    if (_.isString(stdout)) {
-      const executablePath = system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
+    ({stdout} = (await exec(executable, [cmd])));
+    if (stdout) {
+      const executablePath = system.isWindows() ? stdout.split(EOL)[0] : stdout.trim();
       if (await fs.exists(executablePath)) {
         return executablePath;
       }
     }
   } catch (err) {
-    log.debug(err);
+    log.warn(err);
   }
-  log.debug(`No executable path of '${cmd}'. The output of where/which is '${stdout}'`);
+  log.debug(`No executable path of '${cmd}'. The output of ${executable} is '${stdout}'`);
   return null;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ async function resolveExecutablePath (cmd) {
   const executable = system.isWindows() ? 'where' : 'which';
   let stdout;
   try {
-    ({stdout} = (await exec(executable, [cmd])));
+    ({stdout} = await exec(executable, [cmd]));
     if (stdout) {
       const executablePath = system.isWindows() ? stdout.split(EOL)[0] : stdout.trim();
       if (await fs.exists(executablePath)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ import _inquirer from 'inquirer';
 import log from '../lib/logger';
 import authorize from 'authorize-ios';
 import { EOL } from 'os';
-import { system } from 'appium-support';
+import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
 import _ from 'lodash';
 
@@ -41,21 +41,22 @@ function configureBinaryLog (opts) {
  */
 async function resolveExecutablePath (cmd) {
   const executable = system.isWindows() ? 'where' : 'which';
-  let stdout;
   try {
-    stdout = (await exec(executable, [cmd])).stdout;
-    if (stdout.match(/not found/gi)) {
-      throw new Error('Not Found');
+    const stdout = (await exec(executable, [cmd])).stdout;
+    if (_.isString(stdout)) {
+      const executablePath = system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
+      if (await fs.exists(executablePath)) {
+        return executablePath;
+      } else {
+        log.debug(`No executable path of '${cmd}'`);
+        return null;
+      }
+    } else {
+      log.debug(`'${stdout}' is not string`);
+      return null;
     }
   } catch (err) {
     log.debug(err);
-    return null;
-  }
-
-  if (_.isString(stdout)) {
-    return system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
-  } else {
-    log.debug(`'${stdout}' is not string`);
     return null;
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ import authorize from 'authorize-ios';
 import { EOL } from 'os';
 import { system } from 'appium-support';
 import { exec } from 'teen_process';
+import _ from 'lodash';
 
 // rename to make more sense
 const authorizeIos = authorize;
@@ -50,7 +51,13 @@ async function resolveExecutablePath (cmd) {
     log.debug(err);
     return null;
   }
-  return system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
+
+  if (_.isString(stdout)) {
+    return system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
+  } else {
+    log.debug(`'${stdout}' is not string`);
+    return null;
+  }
 }
 
 export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorizeIos, resolveExecutablePath};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ function configureBinaryLog (opts) {
 }
 
 /**
- * Return proper path
+ * Return an executable path of cmd
  *
  * @param {string} cmd Standard output by command
  * @return {?string} The full path of cmd. `null` if the cmd is not found.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,24 +41,20 @@ function configureBinaryLog (opts) {
  */
 async function resolveExecutablePath (cmd) {
   const executable = system.isWindows() ? 'where' : 'which';
+  let stdout;
   try {
-    const stdout = (await exec(executable, [cmd])).stdout;
+    stdout = (await exec(executable, [cmd])).stdout;
     if (_.isString(stdout)) {
       const executablePath = system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
       if (await fs.exists(executablePath)) {
         return executablePath;
-      } else {
-        log.debug(`No executable path of '${cmd}'`);
-        return null;
       }
-    } else {
-      log.debug(`'${stdout}' is not string`);
-      return null;
     }
   } catch (err) {
     log.debug(err);
-    return null;
   }
+  log.debug(`No executable path of '${cmd}'. The output of where/which is '${stdout}'`);
+  return null;
 }
 
 export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorizeIos, resolveExecutablePath};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,9 @@ import path from 'path';
 import _inquirer from 'inquirer';
 import log from '../lib/logger';
 import authorize from 'authorize-ios';
-
+import { EOL } from 'os';
+import { system } from 'appium-support';
+import { exec } from 'teen_process';
 
 // rename to make more sense
 const authorizeIos = authorize;
@@ -30,4 +32,25 @@ function configureBinaryLog (opts) {
   log.level = opts.debug ? 'debug' : 'info';
 }
 
-export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorizeIos, };
+/**
+ * Return proper path
+ *
+ * @param {string} cmd Standard output by command
+ * @return {?string} The full path of cmd. `null` if the cmd is not found.
+ */
+async function resolveExecutablePath (cmd) {
+  const executable = system.isWindows() ? 'where' : 'which';
+  let stdout;
+  try {
+    stdout = (await exec(executable, [cmd])).stdout;
+    if (stdout.match(/not found/gi)) {
+      throw new Error('Not Found');
+    }
+  } catch (err) {
+    log.debug(err);
+    return null;
+  }
+  return system.isWindows() ? stdout.split(EOL)[0] : stdout.replace(EOL, '');
+}
+
+export { pkgRoot, ok, nok, inquirer, configureBinaryLog, authorizeIos, resolveExecutablePath};

--- a/test/dev-specs.js
+++ b/test/dev-specs.js
@@ -34,7 +34,7 @@ describe('dev', function () {
         B.resolve({stdout: 'mvn not found\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
         ok: false,
-        message: 'mvn is MISSING in PATH!'
+        message: 'mvn is MISSING in PATH: /a/b/c/d;/e/f/g/h'
       });
       mocks.verify();
     });
@@ -45,7 +45,7 @@ describe('dev', function () {
       mocks.fs.expects('exists').once().returns(B.resolve(false));
       (await check.diagnose()).should.deep.equal({
         ok: false,
-        message: 'mvn is MISSING in PATH!'
+        message: 'mvn is MISSING in PATH: /a/b/c/d;/e/f/g/h'
       });
       mocks.verify();
     });

--- a/test/dev-specs.js
+++ b/test/dev-specs.js
@@ -45,8 +45,7 @@ describe('dev', function () {
       mocks.fs.expects('exists').once().returns(B.resolve(false));
       (await check.diagnose()).should.deep.equal({
         ok: false,
-        message: 'mvn was found in PATH at \'/a/b/c/d/mvn\', ' +
-          'but this is NOT a valid path!'
+        message: 'mvn is MISSING in PATH!'
       });
       mocks.verify();
     });

--- a/test/node-detector-specs.js
+++ b/test/node-detector-specs.js
@@ -33,10 +33,10 @@ describe('NodeDetector', withSandbox({mocks: {fs, tp, system}}, (S) => {
     }
     it(method + ' - success', async function () {
       S.mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: `/a/b/c/d${EOL}`, stderr: ''}));
+        B.resolve({stdout: `/a/b/c/d/node${EOL}`, stderr: ''}));
       S.mocks.fs.expects('exists').once().returns(B.resolve(true));
       (await NodeDetector[method]())
-        .should.equal('/a/b/c/d');
+        .should.equal('/a/b/c/d/node');
       S.verify();
     });
     it(method + ' - failure - path not found ', async function () {
@@ -59,10 +59,10 @@ describe('NodeDetector', withSandbox({mocks: {fs, tp, system}}, (S) => {
   it('testRetrieveWithScript - success - where returns multiple lines ', async function () {
     S.mocks.system.expects('isWindows').twice().returns(true);
     S.mocks.tp.expects('exec').once().returns(
-      B.resolve({stdout: `/a/b${EOL}/c/d${EOL}`, stderr: ''}));
+      B.resolve({stdout: `/a/b/node${EOL}/c/d/e/node${EOL}`, stderr: ''}));
     S.mocks.fs.expects('exists').once().returns(B.resolve(true));
     (await NodeDetector.retrieveUsingSystemCall())
-      .should.equal('/a/b');
+      .should.equal('/a/b/node');
     S.verify();
   });
 

--- a/test/node-detector-specs.js
+++ b/test/node-detector-specs.js
@@ -6,12 +6,13 @@ import * as tp from 'teen_process';
 import NodeDetector from '../lib/node-detector';
 import B from 'bluebird';
 import { withSandbox } from 'appium-test-support';
+import { EOL } from 'os';
 
 
 chai.should();
 let expect = chai.expect;
 
-describe('NodeDetector', withSandbox({mocks: {fs, tp}}, (S) => {
+describe('NodeDetector', withSandbox({mocks: {fs, tp, system}}, (S) => {
   it('retrieveInCommonPlaces - success', async function () {
     S.mocks.fs.expects('exists').once().returns(B.resolve(true));
     (await NodeDetector.retrieveInCommonPlaces())
@@ -32,18 +33,10 @@ describe('NodeDetector', withSandbox({mocks: {fs, tp}}, (S) => {
     }
     it(method + ' - success', async function () {
       S.mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: '/a/b/c/d\n', stderr: ''}));
+        B.resolve({stdout: `/a/b/c/d${EOL}`, stderr: ''}));
       S.mocks.fs.expects('exists').once().returns(B.resolve(true));
       (await NodeDetector[method]())
         .should.equal('/a/b/c/d');
-      S.verify();
-    });
-    it(method + ' - success - where returns multiple lines ', async function () {
-      S.mocks.tp.expects('exec').once().returns(
-        B.resolve({stdout: '/a/b\n/c/d\n', stderr: ''}));
-      S.mocks.fs.expects('exists').once().returns(B.resolve(true));
-      (await NodeDetector[method]())
-        .should.equal('/a/b');
       S.verify();
     });
     it(method + ' - failure - path not found ', async function () {
@@ -62,6 +55,16 @@ describe('NodeDetector', withSandbox({mocks: {fs, tp}}, (S) => {
 
   testRetrieveWithScript('retrieveUsingSystemCall');
   testRetrieveWithScript('retrieveUsingAppleScript');
+
+  it('testRetrieveWithScript - success - where returns multiple lines ', async function () {
+    S.mocks.system.expects('isWindows').twice().returns(true);
+    S.mocks.tp.expects('exec').once().returns(
+      B.resolve({stdout: `/a/b${EOL}/c/d${EOL}`, stderr: ''}));
+    S.mocks.fs.expects('exists').once().returns(B.resolve(true));
+    (await NodeDetector.retrieveUsingSystemCall())
+      .should.equal('/a/b');
+    S.verify();
+  });
 
   it('retrieveUsingAppiumConfigFile - success', async function () {
     S.mocks.fs.expects('exists').twice().returns(B.resolve(true));

--- a/test/node-detector-specs.js
+++ b/test/node-detector-specs.js
@@ -38,7 +38,14 @@ describe('NodeDetector', withSandbox({mocks: {fs, tp}}, (S) => {
         .should.equal('/a/b/c/d');
       S.verify();
     });
-
+    it(method + ' - success - where returns multiple lines ', async function () {
+      S.mocks.tp.expects('exec').once().returns(
+        B.resolve({stdout: '/a/b\n/c/d\n', stderr: ''}));
+      S.mocks.fs.expects('exists').once().returns(B.resolve(true));
+      (await NodeDetector[method]())
+        .should.equal('/a/b');
+      S.verify();
+    });
     it(method + ' - failure - path not found ', async function () {
       S.mocks.tp.expects('exec').once().returns(
         B.resolve({stdout: 'aaa not found\n', stderr: ''}));


### PR DESCRIPTION
closes https://github.com/appium/appium-doctor/issues/33

On Windows environment, we can get multiple lines as the result of `where node`.
The 1st line is expected node. On *NIX environment like mac, `which` returns one line. This logic can work both environment.

```
$ where node

F:\Tools\nodejs\node.exe
C:\Program Files\nodejs\node.exe
C:\Program Files\Microsoft MPI\Bin\node.exe
```