### PR TITLE
remove deprecated code

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -110,7 +110,7 @@ class AuthorizationDbCheck extends DoctorCheck {
     const errMess = 'The Authorization DB is NOT set up properly.';
     let stdout;
     try {
-      ({stdout} = (await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport'])));
+      ({stdout} = await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport']));
     } catch (err) {
       log.warn(err);
       return nok(errMess);

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -1,5 +1,5 @@
 import { ok, nok, authorizeIos } from './utils'; // eslint-disable-line
-import { fs, system } from 'appium-support';
+import { fs } from 'appium-support';
 import { exec } from 'teen_process';
 import { DoctorCheck, FixSkippedError } from './doctor';
 import log from './logger';
@@ -110,22 +110,10 @@ class AuthorizationDbCheck extends DoctorCheck {
     const errMess = 'The Authorization DB is NOT set up properly.';
     let stdout;
     try {
-      stdout = (await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport'])).stdout;
+      ({stdout} = (await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport'])));
     } catch (err) {
-      if (await system.macOsxVersion() === '10.8') {
-        let data;
-        try {
-          data = await fs.readFile('/etc/authorization', 'utf8');
-        } catch (err) {
-          log.debug(err);
-          return nok(errMess);
-        }
-        let rg = /<key>system.privilege.taskport<\/key>\s*\n\s*<dict>\n\s*<key>allow-root<\/key>\n\s*(<true\/>)/;
-        return data && data.match(rg) ? ok(successMess) : nok(errMess);
-      } else {
-        log.debug(err);
-        return nok(errMess);
-      }
+      log.warn(err);
+      return nok(errMess);
     }
     return stdout && (stdout.match(/is-developer/) || stdout.match(/allow/)) ?
       ok(successMess) : nok(errMess);

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -175,7 +175,7 @@ describe('ios', function () {
     it('autofix', function () {
       check.autofix.should.be.ok;
     });
-    it('diagnose - success - 10.10', async function () {
+    it('diagnose - success', async function () {
       mocks.tp.expects('exec').once().returns(
         B.resolve({stdout: '1234 is-developer\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
@@ -184,30 +184,8 @@ describe('ios', function () {
       });
       mocks.verify();
     });
-    it('diagnose - success - 10.8', async function () {
+    it('diagnose - failure', async function () {
       mocks.tp.expects('exec').once().returns(B.reject(new Error('Oh No!')));
-      mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.8'));
-      mocks.fs.expects('readFile').once().returns(B.resolve(
-        '<key>system.privilege.taskport</key> \n <dict>\n <key>allow-root</key>\n <true/>'));
-      (await check.diagnose()).should.deep.equal({
-        ok: true,
-        message: 'The Authorization DB is set up properly.'
-      });
-      mocks.verify();
-    });
-    it('diagnose - failure - 10.10 - security', async function () {
-      mocks.tp.expects('exec').once().returns(B.reject(new Error('Oh No!')));
-      mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.10'));
-      (await check.diagnose()).should.deep.equal({
-        ok: false,
-        message: 'The Authorization DB is NOT set up properly.'
-      });
-      mocks.verify();
-    });
-    it('diagnose - failure - /etc/authorization', async function () {
-      mocks.tp.expects('exec').once().returns(B.reject(new Error('Oh No!')));
-      mocks.system.expects('macOsxVersion').once().returns(B.resolve('10.8'));
-      mocks.fs.expects('readFile').once().returns(B.resolve(''));
       (await check.diagnose()).should.deep.equal({
         ok: false,
         message: 'The Authorization DB is NOT set up properly.'


### PR DESCRIPTION
https://www.dssw.co.uk/blog/2013-10-26-authorization-rights-and-mavericks/
`/etc/authorization` is no longer used since our minimum support version is over 10.8