### PR TITLE
Tweak printed message

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -42,7 +42,7 @@ class XcodeCmdLineToolsCheck extends DoctorCheck {
     try {
       // https://stackoverflow.com/questions/15371925/how-to-check-if-command-line-tools-is-installed
       const stdout = (await exec('xcode-select', ['-p'])).stdout;
-      return ok(`Xcode Command Line Tools are installed in: ${stdout}`);
+      return ok(`Xcode Command Line Tools are installed in: ${stdout.trim()}`);
     } catch (err) {
       log.debug(err);
       return nok(errMess);

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -112,7 +112,7 @@ class AuthorizationDbCheck extends DoctorCheck {
     try {
       ({stdout} = await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport']));
     } catch (err) {
-      log.warn(err);
+      log.debug(err);
       return nok(errMess);
     }
     return stdout && (stdout.match(/is-developer/) || stdout.match(/allow/)) ?

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,7 @@ async function resolveExecutablePath (cmd) {
       }
     }
   } catch (err) {
-    log.warn(err);
+    log.debug(err);
   }
   log.debug(`No executable path of '${cmd}'. The output of ${executable} is '${stdout}'`);
   return null;

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -66,7 +66,7 @@ describe('ios', function () {
         B.resolve({stdout: '/Applications/Xcode.app/Contents/Developer\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
         ok: true,
-        message: 'Xcode Command Line Tools are installed in: /Applications/Xcode.app/Contents/Developer\n'
+        message: 'Xcode Command Line Tools are installed in: /Applications/Xcode.app/Contents/Developer'
       });
       S.verify();
     });


### PR DESCRIPTION
- warning messages are printed as the result of `appium-doctor` command like below in addition to expected `nok` message
    ```
    WARN AppiumDoctor Error: Command 'which fbsimctl' exited with code 1
    WARN AppiumDoctor     at ChildProcess.proc.on.code (/Users/kazuaki/GitHub/appium-doctor/node_modules/teen_process/lib/exec.js:94:19)
    WARN AppiumDoctor     at ChildProcess.emit (events.js:182:13)
    WARN AppiumDoctor     at maybeClose (internal/child_process.js:962:16)
    WARN AppiumDoctor     at Process.ChildProcess._handle.onexit (internal/child_process.js:251:5)
    ```
- Remove new line to remove redundant new line form the output