### PR TITLE
[do not merge]Add options

### DIFF
--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -39,7 +39,7 @@ class Doctor {
       if (res.ok) {
         log.info(` ${'\u2714'.green} ${res.message}`);
       } else {
-        let errorMessage = ` ${'\u2716'.red} ${res.message}`;
+        const errorMessage = res.option ? ` ${'\u2716 [option]'.yellow} ${res.message}` : ` ${'\u2716'.red} ${res.message}`;
         log.warn(errorMessage);
         this.toFix.push({
           error: errorMessage,

--- a/lib/general.js
+++ b/lib/general.js
@@ -2,6 +2,7 @@ import { ok, nok } from './utils';
 import { exec } from 'teen_process';
 import { DoctorCheck } from './doctor';
 import NodeDetector from './node-detector';
+import log from './logger';
 
 
 let checks = [];
@@ -42,6 +43,25 @@ class NodeVersionCheck extends DoctorCheck {
   }
 }
 checks.push(new NodeVersionCheck());
+
+class OptionalOpencv4nodejsCommandCheck extends DoctorCheck {
+  async diagnose () {
+    let stdout = '';
+    try {
+      ({stdout} = await exec('npm', ['list', '-g', 'opencv4nodejs']));
+    } catch (err) {
+      log.debug(err);
+    }
+    return stdout.includes('opencv4nodejs')
+      ? ok('opencv4nodejs is installed.')
+      : nok('opencv4nodejs cannot be found', true);
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return `${'[option]'.yellow} Manually install them: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/image-comparison.md`;
+  }
+}
+checks.push(new OptionalOpencv4nodejsCommandCheck());
 
 export { NodeBinaryCheck, NodeVersionCheck };
 export default checks;

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -42,7 +42,7 @@ class XcodeCmdLineToolsCheck extends DoctorCheck {
     try {
       // https://stackoverflow.com/questions/15371925/how-to-check-if-command-line-tools-is-installed
       const stdout = (await exec('xcode-select', ['-p'])).stdout;
-      return ok(`Xcode Command Line Tools are installed in: ${stdout}`);
+      return ok(`Xcode Command Line Tools are installed in: ${stdout.trim()}`);
     } catch (err) {
       log.debug(err);
       return nok(errMess);

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -112,7 +112,7 @@ class AuthorizationDbCheck extends DoctorCheck {
     try {
       ({stdout} = await exec('security', ['authorizationdb', 'read', 'system.privilege.taskport']));
     } catch (err) {
-      log.warn(err);
+      log.debug(err);
       return nok(errMess);
     }
     return stdout && (stdout.match(/is-developer/) || stdout.match(/allow/)) ?

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -1,4 +1,4 @@
-import { ok, nok, authorizeIos } from './utils'; // eslint-disable-line
+import { ok, nok, authorizeIos, resolveExecutablePath } from './utils'; // eslint-disable-line
 import { fs } from 'appium-support';
 import { exec } from 'teen_process';
 import { DoctorCheck, FixSkippedError } from './doctor';
@@ -141,6 +141,34 @@ class CarthageCheck extends DoctorCheck {
 checks.push(new CarthageCheck());
 
 checks.push(new EnvVarAndPathCheck('HOME'));
+
+class OptionalFbsimctlCommandCheck extends DoctorCheck {
+  async diagnose () {
+    const fbsimctlPath = await resolveExecutablePath('fbsimctl');
+    return fbsimctlPath
+      ? ok(`fbsimctl is installed at: ${fbsimctlPath}. Installed versions are: ${(await exec('brew', ['list', '--versions', 'fbsimctl'])).stdout.trim()}`)
+      : nok('fbsimctl cannot be found', true);
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return `${'[option]'.yellow} Manually install them: http://appium.io/docs/en/drivers/ios-xcuitest/`;
+  }
+}
+checks.push(new OptionalFbsimctlCommandCheck());
+
+class OptionalApplesimutilsCommandCheck extends DoctorCheck {
+  async diagnose () {
+    const applesimutilsPath = await resolveExecutablePath('applesimutils');
+    return applesimutilsPath
+      ? ok(`applesimutils is installed at: ${applesimutilsPath}. Installed versions are: ${(await exec('brew', ['list', '--versions', 'applesimutils'])).stdout.trim()}`)
+      : nok('fbsimctl cannot be found', true);
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return `${'[option]'.yellow} Manually install them: http://appium.io/docs/en/drivers/ios-xcuitest/`;
+  }
+}
+checks.push(new OptionalApplesimutilsCommandCheck());
 
 export {
   fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ const pkgRoot = process.env.NO_PRECOMPILE ?
   path.resolve(__dirname, '..') : path.resolve(__dirname, '..', '..');
 
 const ok = (message) => { return {ok: true, message}; };
-const nok = (message) => { return {ok: false, message}; };
+const nok = (message, option = false) => { return {ok: false, option, message}; };
 
 const inquirer = {
   prompt: B.promisify(function (question, cb) { // eslint-disable-line promise/prefer-await-to-callbacks

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,7 @@ async function resolveExecutablePath (cmd) {
       }
     }
   } catch (err) {
-    log.warn(err);
+    log.debug(err);
   }
   log.debug(`No executable path of '${cmd}'. The output of ${executable} is '${stdout}'`);
   return null;

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -66,7 +66,7 @@ describe('ios', function () {
         B.resolve({stdout: '/Applications/Xcode.app/Contents/Developer\n', stderr: ''}));
       (await check.diagnose()).should.deep.equal({
         ok: true,
-        message: 'Xcode Command Line Tools are installed in: /Applications/Xcode.app/Contents/Developer\n'
+        message: 'Xcode Command Line Tools are installed in: /Applications/Xcode.app/Contents/Developer'
       });
       S.verify();
     });


### PR DESCRIPTION
What about adding options like below to show what command users can use?

![image](https://user-images.githubusercontent.com/5511591/49697555-6cc54c80-fbfc-11e8-9aba-11d8e573e1f0.png)

They are not mandatory features so we have not probably introduced them into `doctor`.
When I used `flutter-doctor`, I was able to notice what options I could use for it. I felt that was helpful to start using it from the doctor command.

note: Tests in this PR fail. I have not add tests.
(This PR's base branch is ac195a1)

I would like to close this PR if we do not need this kind of note for users.