### PR TITLE
add android app bundle tool

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -63,9 +63,9 @@ checks.push(new JavaOnPathCheck());
 
 class OptionalAppBundleCheck extends DoctorCheck {
   async diagnose () {
-    const idevicelocationPath = await resolveExecutablePath('bundletool.jar');
-    return idevicelocationPath
-      ? okOptional(`bundletool.jar is installed at: ${idevicelocationPath}`)
+    const bundletoolPath = await resolveExecutablePath('bundletool.jar');
+    return bundletoolPath
+      ? okOptional(`bundletool.jar is installed at: ${bundletoolPath}`)
       : nokOptional('bundletool.jar cannot be found');
   }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -1,5 +1,5 @@
 import { DoctorCheck } from './doctor';
-import { ok, nok } from './utils';
+import { ok, nok, okOptional, nokOptional, resolveExecutablePath } from './utils';
 import { fs, system } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
@@ -61,5 +61,19 @@ checks.push(new AndroidToolCheck('emulator',
   path.join("tools", system.isWindows() ? 'emulator.exe' : 'emulator')));
 checks.push(new JavaOnPathCheck());
 
-export { EnvVarAndPathCheck, AndroidToolCheck, JavaOnPathCheck };
+class OptionalAppBundleCheck extends DoctorCheck {
+  async diagnose () {
+    const idevicelocationPath = await resolveExecutablePath('bundletool.jar');
+    return idevicelocationPath
+      ? okOptional(`bundletool.jar is installed at: ${idevicelocationPath}`)
+      : nokOptional('bundletool.jar cannot be found');
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return 'bundletool.jar is used to handle Android App Bundle. Please read http://appium.io/docs/en/writing-running-appium/android/android-appbundle/ to install it';
+  }
+}
+checks.push(new OptionalAppBundleCheck());
+
+export { EnvVarAndPathCheck, AndroidToolCheck, JavaOnPathCheck, OptionalAppBundleCheck };
 export default checks;


### PR DESCRIPTION
an example:

```
...
info AppiumDoctor  ✔ applesimutils is installed at: /usr/local/bin/applesimutils. Installed versions are: applesimutils 0.6.2
WARN AppiumDoctor  ✖ idevicelocation cannot be found
info AppiumDoctor  ✔ bundletool.jar is installed at: /Users/kazu/GitHub/AppBundleSample/apks/bundletool.jar
info AppiumDoctor ### Diagnostic for optional dependencies completed, 2 fixes needed. ###
info AppiumDoctor
...
```