### PR TITLE
Catch fbversion check error

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -153,9 +153,9 @@ class OptionalFbsimctlCommandCheck extends DoctorCheck {
       } catch {
         return okOptional(`fbsimctl is installed at: ${fbsimctlPath}. It is prbably installed as custom install.`);
       }
-    } else {
-      return nokOptional('fbsimctl cannot be found');
     }
+
+    return nokOptional('fbsimctl cannot be found');
   }
 
   async fix () { // eslint-disable-line require-await

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -145,7 +145,6 @@ checks.push(new EnvVarAndPathCheck('HOME'));
 class OptionalFbsimctlCommandCheck extends DoctorCheck {
   async diagnose () {
     const fbsimctlPath = await resolveExecutablePath('fbsimctl');
-
     if (fbsimctlPath) {
       try {
         const fbsimctlVersion = (await exec('brew', ['list', '--versions', 'fbsimctl'])).stdout.trim();

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -145,9 +145,17 @@ checks.push(new EnvVarAndPathCheck('HOME'));
 class OptionalFbsimctlCommandCheck extends DoctorCheck {
   async diagnose () {
     const fbsimctlPath = await resolveExecutablePath('fbsimctl');
-    return fbsimctlPath
-      ? okOptional(`fbsimctl is installed at: ${fbsimctlPath}. Installed versions are: ${(await exec('brew', ['list', '--versions', 'fbsimctl'])).stdout.trim()}`)
-      : nokOptional('fbsimctl cannot be found');
+
+    if (fbsimctlPath) {
+      try {
+        const fbsimctlVersion = (await exec('brew', ['list', '--versions', 'fbsimctl'])).stdout.trim();
+        return okOptional(`fbsimctl is installed at: ${fbsimctlPath}. Installed versions are: ${fbsimctlVersion}`);
+      } catch {
+        return okOptional(`fbsimctl is installed at: ${fbsimctlPath}. It is prbably installed as custom install.`);
+      }
+    } else {
+      return nokOptional('fbsimctl cannot be found');
+    }
   }
 
   async fix () { // eslint-disable-line require-await

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -252,6 +252,16 @@ describe('ios', function () {
       });
       mocks.verify();
     });
+    it('diagnose - success - custom install', async function () {
+      mocks.utils.expects('resolveExecutablePath').once().returns('path/to/fbsimctl');
+      mocks.tp.expects('exec').once().throws(`Command 'brew list --versions fbsimctl' exited with code 1`);
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        optional: true,
+        message: 'fbsimctl is installed at: path/to/fbsimctl. It is prbably installed as custom install.'
+      });
+      mocks.verify();
+    });
     it('diagnose - failure', async function () {
       mocks.utils.expects('resolveExecutablePath').once().returns(false);
       (await check.diagnose()).should.deep.equal({


### PR DESCRIPTION
https://github.com/appium/appium/issues/11986
Current implementation tries to show installed command version. But if a user installs `fbsimctl` via custom install way, we have no way to detect the version and brew command, current implementation, raises an error.
In this PR, the doctor catches the error and show another message.