### PR TITLE
Change wording for optional fixes

### DIFF
--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -52,7 +52,7 @@ class Doctor {
     for (const checkOptional of this.checkOptionals) {
       await this.diagnosticResultMessage(await checkOptional.diagnose(), this.toFixOptionals, checkOptional);
     }
-    log.info(`### Diagnostic for optional dependencies completed, ${await this.fixMessage(this.toFixOptionals.length)}. ###`);
+    log.info(`### Diagnostic for optional dependencies completed, ${await this.fixMessage(this.toFixOptionals.length, true)}. ###`);
     log.info('');
   }
 
@@ -165,15 +165,19 @@ class Doctor {
     }
   }
 
-  async fixMessage (length) { // eslint-disable-line require-await
+  async fixMessage (length, optional = false) { // eslint-disable-line require-await
+    let message;
     switch (length) {
       case 0:
-        return 'no fix needed';
+        message = 'no fix';
+        break;
       case 1:
-        return 'one fix needed';
+        message = 'one fix';
+        break;
       default:
-        return `${length} fixes needed`;
+        message = `${length} fixes`;
     }
+    return `${message} ${optional ? 'possible' : 'needed'}`;
   }
 
   async reportSuccess (length, lengthOptional) { // eslint-disable-line require-await

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
     "lint": "gulp eslint",
-    "lint:fix": "gulp eslint --fix"
+    "lint:fix": "gulp eslint --fix",
+    "build": "gulp transpile"
   },
   "pre-commit": [
     "precommit-msg",

--- a/test/doctor-specs.js
+++ b/test/doctor-specs.js
@@ -50,7 +50,7 @@ describe('doctor', function () {
         'info: ### Diagnostic for optional dependencies starting ###',
         'info:  ✔ All Good Option!',
         'warn:  ✖ Oh No Option!',
-        'info: ### Diagnostic for optional dependencies completed, one fix needed. ###',
+        'info: ### Diagnostic for optional dependencies completed, one fix possible. ###',
         'info: ',
       ].join('\n'));
     });


### PR DESCRIPTION
Optional fixes are not, strictly speaking, "needed".

```
info AppiumDoctor ### Diagnostic for optional dependencies starting ###
WARN AppiumDoctor  ✖ opencv4nodejs cannot be found.
WARN AppiumDoctor  ✖ ffmpeg cannot be found
WARN AppiumDoctor  ✖ fbsimctl cannot be found
WARN AppiumDoctor  ✖ applesimutils cannot be found
WARN AppiumDoctor  ✖ idevicelocation cannot be found
WARN AppiumDoctor  ✖ bundletool.jar cannot be found
info AppiumDoctor ### Diagnostic for optional dependencies completed, 6 fixes needed. ###
```

```
info AppiumDoctor ### Diagnostic for optional dependencies starting ###
WARN AppiumDoctor  ✖ opencv4nodejs cannot be found.
WARN AppiumDoctor  ✖ ffmpeg cannot be found
WARN AppiumDoctor  ✖ fbsimctl cannot be found
WARN AppiumDoctor  ✖ applesimutils cannot be found
WARN AppiumDoctor  ✖ idevicelocation cannot be found
WARN AppiumDoctor  ✖ bundletool.jar cannot be found
info AppiumDoctor ### Diagnostic for optional dependencies completed, 6 fixes possible. ###
```