### PR TITLE
add a path of opencv4nodejs and the version

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -54,9 +54,11 @@ class OptionalOpencv4nodejsCommandCheck extends DoctorCheck {
     } catch (err) {
       log.debug(err);
     }
-    return stdout.includes(paclageName)
-      ? okOptional(`${paclageName} is installed.`)
-      : nokOptional(`${paclageName} cannot be found.`);
+    if (stdout.includes(paclageName)) {
+      const eachLine = stdout.split(EOL);
+      return okOptional(`${paclageName} is installed at: ${eachLine[0]}. Installed version is: ${eachLine[1].replace('└── opencv4nodejs@', '')}`);
+    }
+    return nokOptional(`${paclageName} cannot be found.`);
   }
 
   async fix () { // eslint-disable-line require-await

--- a/lib/general.js
+++ b/lib/general.js
@@ -47,18 +47,21 @@ checks.push(new NodeVersionCheck());
 class OptionalOpencv4nodejsCommandCheck extends DoctorCheck {
   async diagnose () {
     let stdout = '';
-    const paclageName = 'opencv4nodejs';
+    const packageName = 'opencv4nodejs';
 
     try {
-      ({stdout} = await exec('npm', ['list', '-g', paclageName]));
+      ({stdout} = await exec('npm', ['list', '-g', packageName]));
     } catch (err) {
       log.debug(err);
     }
-    if (stdout.includes(paclageName)) {
-      const eachLine = stdout.split(EOL);
-      return okOptional(`${paclageName} is installed at: ${eachLine[0]}. Installed version is: ${eachLine[1].replace('└── opencv4nodejs@', '')}`);
+    if (stdout.includes(packageName)) {
+      const lines = stdout.split(EOL);
+      const openvcLib = lines.find(function (line) { return line.includes(`${packageName}@`); });
+      return (openvcLib)
+        ? okOptional(`${packageName} is installed at: ${lines[0]}. Installed version is: ${openvcLib.match(/(\d(\.\d+)*)/g).pop()}`)
+        : okOptional(`${packageName} is probably installed at: ${lines[0]}.`);
     }
-    return nokOptional(`${paclageName} cannot be found.`);
+    return nokOptional(`${packageName} cannot be found.`);
   }
 
   async fix () { // eslint-disable-line require-await

--- a/test/general-specs.js
+++ b/test/general-specs.js
@@ -96,6 +96,15 @@ describe('general', function () {
       });
       mocks.verify();
     });
+    it('diagnose - success, but not sure if the library exist, no opencv4nodejs@4.13.0', async function () {
+      mocks.tp.expects('exec').once().returns({stdout: `/path/to/node/node/v11.4.0/opencv4nodejs`, stderr: ''});
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        optional: true,
+        message: 'opencv4nodejs is probably installed at: /path/to/node/node/v11.4.0/opencv4nodejs.'
+      });
+      mocks.verify();
+    });
     it('diagnose - failure', async function () {
       mocks.tp.expects('exec').once().returns({stdout: 'not found', stderr: ''});
       (await check.diagnose()).should.deep.equal({

--- a/test/general-specs.js
+++ b/test/general-specs.js
@@ -88,11 +88,11 @@ describe('general', function () {
       check.autofix.should.not.be.ok;
     });
     it('diagnose - success', async function () {
-      mocks.tp.expects('exec').once().returns({stdout: '/path/to/opencv4nodejs', stderr: ''});
+      mocks.tp.expects('exec').once().returns({stdout: `/path/to/node/node/v11.4.0/lib\n└── opencv4nodejs@4.13.0`, stderr: ''});
       (await check.diagnose()).should.deep.equal({
         ok: true,
         optional: true,
-        message: 'opencv4nodejs is installed.'
+        message: 'opencv4nodejs is installed at: /path/to/node/node/v11.4.0/lib. Installed version is: 4.13.0'
       });
       mocks.verify();
     });


### PR DESCRIPTION
A tiny improvement for opencv4nodejs.
Users confuse the path to opencv4nodejs, since npm has local and global dependencies.
Showing the path Appium refer to helps such case.

```
info AppiumDoctor  ✔ opencv4nodejs is installed at: /Users/kazuaki/.nodebrew/node/v11.4.0/lib. installed version is: 4.13.0
```