### PR TITLE
add python 2 check sinve node-gyp requires it

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -45,6 +45,35 @@ class NodeVersionCheck extends DoctorCheck {
 }
 checks.push(new NodeVersionCheck());
 
+// Python version check which is required by https://github.com/nodejs/node-gyp
+class PythonVersionCheck extends DoctorCheck {
+  async diagnose () {
+    const pythonPath = await resolveExecutablePath(`python${system.isWindows() ? `.EXE` : ''}`);
+    if (!pythonPath) {
+      return nok(`Python required by node-gyp not found in PATH: ${process.env.PATH}`);
+    }
+
+    // It can return version number as stderr
+    const {stdout, stderr} = await exec(pythonPath, ['-V']);
+    let versionString = `${stdout} ${stderr}`.match(/Python (\d(\.\d+)*)/g);
+    if (versionString) {
+      versionString = versionString.pop().replace('Python ', '');
+    }
+    const version = parseInt(versionString, 10);
+    if (Number.isNaN(version)) {
+      return nok(`Unable to identify Python version correctly(version = '${versionString}') at ${pythonPath}. Please make sure your environment. node-gyp requires Python 2.x`);
+    }
+    return version === 2 ? ok(`Python required by node-gyp is installed at: ${pythonPath}. Installed version is: ${versionString}`) :
+      nok('Python version required by node-gyp should be 2.x');
+  }
+
+  fix () {
+    return `Manually configure Python 2.x environment. node-gyp which is NodeJS toolchain requires Python 2.x`;
+  }
+}
+checks.push(new PythonVersionCheck());
+
+
 class OptionalOpencv4nodejsCommandCheck extends DoctorCheck {
   async diagnose () {
     let stdout = '';
@@ -90,5 +119,6 @@ class OptionalFfmpegCommandCheck extends DoctorCheck {
 }
 checks.push(new OptionalFfmpegCommandCheck());
 
-export { NodeBinaryCheck, NodeVersionCheck, OptionalOpencv4nodejsCommandCheck, OptionalFfmpegCommandCheck };
+export { NodeBinaryCheck, NodeVersionCheck, PythonVersionCheck,
+  OptionalOpencv4nodejsCommandCheck, OptionalFfmpegCommandCheck };
 export default checks;


### PR DESCRIPTION
Recently, I saw below issues.

node-gyp requires Python 2 so far. Users should have the version to complete installing Appium.
What about guiding the version with which library requires it as a part of doctor?

https://github.com/appium/appium/issues/12087
