### PR TITLE
make xcode check reliable

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -17,7 +17,10 @@ class XcodeCheck extends DoctorCheck {
   async diagnose () {
     let xcodePath;
     try {
-      let {stdout} = await exec('xcode-select', ['--print-path']);
+      // https://github.com/appium/appium/issues/12093#issuecomment-459358120 can happen
+      await exec('xcrun', ['simctl', 'help']);
+
+      const {stdout} = await exec('xcode-select', ['-p']);
       xcodePath = (stdout || '').replace('\n', '');
     } catch (err) {
       return nok('Xcode is NOT installed!');
@@ -27,7 +30,7 @@ class XcodeCheck extends DoctorCheck {
   }
 
   async fix () { // eslint-disable-line require-await
-    return 'Manually install Xcode.';
+    return "Manually install Xcode, and make sure 'xcode-select -p' command shows proper path like '/Applications/Xcode.app/Contents/Developer'";
   }
 }
 checks.push(new XcodeCheck());


### PR DESCRIPTION
I noticed `xcode-select -p` was `/Library/Developer/CommandLineTools/` case could happen.
Then, Xcode commands such as `xcrun simctl` failed.

It can happen when a user installs command line tool via `xcode-select --install` while the user has no Xcode.app in their environment. Then, `xcode-select -p` becomes `/Library/Developer/CommandLineTools/`.

If a user installs Xcode first, the path becomes `/Applications/Xcode.app/Contents/Developer`. In this case, this case does not happen.

It can fix installing Xcode manually and change the path to  `/Applications/Xcode.app/Contents/Developer` from `/Library/Developer/CommandLineTools/`.

https://github.com/appium/appium/issues/12093#issuecomment-459358120