### PR TITLE
add mjpeg consumer check

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -137,9 +137,9 @@ class OptionalMjpegConsumerCommandCheck extends DoctorCheck {
     }
     if (stdout.includes(packageName)) {
       const lines = stdout.split(EOL);
-      const openvcLib = lines.find(function (line) { return line.includes(`${packageName}@`); });
-      return (openvcLib)
-        ? okOptional(`${packageName} is installed at: ${lines[0]}. Installed version is: ${openvcLib.match(/(\d(\.\d+)*)/g).pop()}`)
+      const mjpegConsumerLib = lines.find(function (line) { return line.includes(`${packageName}@`); });
+      return (mjpegConsumerLib)
+        ? okOptional(`${packageName} is installed at: ${lines[0]}. Installed version is: ${mjpegConsumerLib.match(/(\d(\.\d+)*)/g).pop()}`)
         : okOptional(`${packageName} is probably installed at: ${lines[0]}.`);
     }
     return nokOptional(`${packageName} cannot be found.`);

--- a/lib/general.js
+++ b/lib/general.js
@@ -137,7 +137,7 @@ class OptionalMjpegConsumerCommandCheck extends DoctorCheck {
     }
     if (stdout.includes(packageName)) {
       const lines = stdout.split(EOL);
-      const mjpegConsumerLib = lines.find(function (line) { return line.includes(`${packageName}@`); });
+      const mjpegConsumerLib = stdout.split(EOL).find((line) => line.includes(`${packageName}@`));
       return (mjpegConsumerLib)
         ? okOptional(`${packageName} is installed at: ${lines[0]}. Installed version is: ${mjpegConsumerLib.match(/(\d(\.\d+)*)/g).pop()}`)
         : okOptional(`${packageName} is probably installed at: ${lines[0]}.`);

--- a/lib/general.js
+++ b/lib/general.js
@@ -119,6 +119,39 @@ class OptionalFfmpegCommandCheck extends DoctorCheck {
 }
 checks.push(new OptionalFfmpegCommandCheck());
 
+
+class OptionalMjpegConsumerCommandCheck extends DoctorCheck {
+  async diagnose () {
+    let stdout = '';
+    const packageName = 'mjpeg-consumer';
+
+    const npmPath = await resolveExecutablePath(`npm${system.isWindows() ? `.cmd` : ''}`);
+    if (!npmPath) {
+      return nokOptional(`'npm' binary not found in PATH: ${process.env.PATH}`);
+    }
+
+    try {
+      ({stdout} = await exec(npmPath, ['list', '-g', packageName]));
+    } catch (err) {
+      log.debug(err);
+    }
+    if (stdout.includes(packageName)) {
+      const lines = stdout.split(EOL);
+      const openvcLib = lines.find(function (line) { return line.includes(`${packageName}@`); });
+      return (openvcLib)
+        ? okOptional(`${packageName} is installed at: ${lines[0]}. Installed version is: ${openvcLib.match(/(\d(\.\d+)*)/g).pop()}`)
+        : okOptional(`${packageName} is probably installed at: ${lines[0]}.`);
+    }
+    return nokOptional(`${packageName} cannot be found.`);
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return 'mjpeg-consumer module is required to use MJPEG-over-HTTP features. Please install it with `npm i -g mjpeg-consumer`.';
+  }
+}
+checks.push(new OptionalMjpegConsumerCommandCheck());
+
+
 export { NodeBinaryCheck, NodeVersionCheck, OptionalPythonVersionCheck,
-  OptionalOpencv4nodejsCommandCheck, OptionalFfmpegCommandCheck };
+  OptionalOpencv4nodejsCommandCheck, OptionalFfmpegCommandCheck, OptionalMjpegConsumerCommandCheck };
 export default checks;


### PR DESCRIPTION
`mjpeg-consumer` case.

The logic is almost the same as opencv4nodejs.
If the same logic increase more, I would like to extract it as helper methods.