### PR TITLE
add a message for windows in bundletool check

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -72,7 +72,6 @@ class OptionalAppBundleCheck extends DoctorCheck {
   async fix () { // eslint-disable-line require-await
     return 'bundletool.jar is used to handle Android App Bundle. Please read http://appium.io/docs/en/writing-running-appium/android/android-appbundle/ to install it' +
       `${system.isWindows() ? '. Also consider adding the ".jar" extension into your PATHEXT environment variable in order to fix the problem for Windows' : ''}`;
-
   }
 }
 checks.push(new OptionalAppBundleCheck());

--- a/lib/android.js
+++ b/lib/android.js
@@ -71,7 +71,8 @@ class OptionalAppBundleCheck extends DoctorCheck {
 
   async fix () { // eslint-disable-line require-await
     return 'bundletool.jar is used to handle Android App Bundle. Please read http://appium.io/docs/en/writing-running-appium/android/android-appbundle/ to install it' +
-      `${system.isWindows() ? '. Please consider adding ".JAR" in your PATHEXT in order to find it' : ''}`;
+      `${system.isWindows() ? '. Also consider adding the ".jar" extension into your PATHEXT environment variable in order to fix the problem for Windows' : ''}`;
+
   }
 }
 checks.push(new OptionalAppBundleCheck());

--- a/lib/android.js
+++ b/lib/android.js
@@ -70,7 +70,8 @@ class OptionalAppBundleCheck extends DoctorCheck {
   }
 
   async fix () { // eslint-disable-line require-await
-    return 'bundletool.jar is used to handle Android App Bundle. Please read http://appium.io/docs/en/writing-running-appium/android/android-appbundle/ to install it';
+    return 'bundletool.jar is used to handle Android App Bundle. Please read http://appium.io/docs/en/writing-running-appium/android/android-appbundle/ to install it' +
+      `${system.isWindows() ? '. Please consider adding ".JAR" in your PATHEXT in order to find it' : ''}`;
   }
 }
 checks.push(new OptionalAppBundleCheck());


### PR DESCRIPTION
According to https://github.com/appium/appium/issues/12269#issuecomment-486553116, node-which can find the module by adding '.JAR' in their PATHEXT..