### PR TITLE
add ifuse for iOS

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -1,5 +1,5 @@
 import { ok, nok, okOptional, nokOptional, authorizeIos, resolveExecutablePath } from './utils'; // eslint-disable-line
-import { fs, coerceVersion } from 'appium-support';
+import { fs, util } from 'appium-support';
 import { exec } from 'teen_process';
 import { DoctorCheck, FixSkippedError } from './doctor';
 import log from './logger';
@@ -140,7 +140,7 @@ class CarthageCheck extends DoctorCheck {
         // 'Please update to the latest Carthage version: 0.33.0. You currently are on 0.32.0\n0.32.0\n' or '0.32.0\n'
         // 0.32.0 is the current version. 0.33.0 is an available newer version.
         version = _.last(stdout.match(/(\d+\.\d+\.\d+)/g));
-        if (!coerceVersion(version, false)) {
+        if (!util.coerceVersion(version, false)) {
           log.warn(`Cannot parse Carthage version from ${stdout}`);
         }
       } catch (err) {

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -230,8 +230,7 @@ class OptionalIfuseCommandCheck extends DoctorCheck {
   async diagnose () {
     const ifusePath = await resolveExecutablePath('ifuse');
     if (ifusePath) {
-      const {stdout, stderr} = await exec(ifusePath, ['-V']);
-      const version = `${stdout.trim()}${stderr.trim()}`;
+      const version = (await exec(ifusePath, ['-V'])).stderr;
       return okOptional(`ifuse is installed at: ${ifusePath}. Installed version is: ${/[0-9.]+/.exec(version)[0]}`);
     }
     return nokOptional('ifuse cannot be found');

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -231,7 +231,7 @@ class OptionalIfuseCommandCheck extends DoctorCheck {
     const ifusePath = await resolveExecutablePath('ifuse');
     if (ifusePath) {
       const version = (await exec(ifusePath, ['-V'])).stderr;
-      return okOptional(`ifuse is installed at: ${ifusePath}. Installed version is: ${/[0-9.]+/.exec(version)[0]}`);
+      return okOptional(`ifuse is installed at: ${ifusePath}.${ version ? ` Installed version is: ${/[0-9.]+/.exec(version)[0]}` : ''}`);
     }
     return nokOptional('ifuse cannot be found');
   }

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -230,9 +230,9 @@ class OptionalIfuseCommandCheck extends DoctorCheck {
   async diagnose () {
     const ifusePath = await resolveExecutablePath('ifuse');
     if (ifusePath) {
-      const {stdout, stderr} = (await exec(ifusePath, ['-V']));
+      const {stdout, stderr} = await exec(ifusePath, ['-V']);
       const version = `${stdout.trim()}${stderr.trim()}`;
-      return okOptional(`ifuse is installed at: ${ifusePath}. Installed version is: ${/[0-9.]+/.exec(version)}`);
+      return okOptional(`ifuse is installed at: ${ifusePath}. Installed version is: ${/[0-9.]+/.exec(version)[0]}`);
     }
     return nokOptional('ifuse cannot be found');
   }

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -254,7 +254,7 @@ class OptionalIfuseCommandCheck extends DoctorCheck {
   }
 
   async fix () { // eslint-disable-line require-await
-    return 'ifuse is used to manage files/folders against a real device. Please run `brew cask install osxfuse && brew install ifuse --HEAD` or read https://github.com/libimobiledevice/ifuse to install it';
+    return 'ifuse is used to manage files/folders against a real device. Please read https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/ios/ios-xctest-file-movement.md to install it';
   }
 }
 checks.push(new OptionalIfuseCommandCheck());

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -226,9 +226,27 @@ class OptionalIOSWebkitDebugProxyCommandCheck extends DoctorCheck {
 }
 checks.push(new OptionalIOSWebkitDebugProxyCommandCheck());
 
+class OptionalIfuseCommandCheck extends DoctorCheck {
+  async diagnose () {
+    const ifusePath = await resolveExecutablePath('ifuse');
+    if (ifusePath) {
+      const {stdout, stderr} = (await exec(ifusePath, ['-V']));
+      const version = `${stdout.trim()}${stderr.trim()}`;
+      return okOptional(`ifuse is installed at: ${ifusePath}. Installed version is: ${/[0-9.]+/.exec(version)}`);
+    }
+    return nokOptional('ifuse cannot be found');
+  }
+
+  async fix () { // eslint-disable-line require-await
+    return 'ifuse is used to manage files/folders against a real device. Please run `brew cask install osxfuse && brew install ifuse --HEAD` or read https://github.com/libimobiledevice/ifuse to install it';
+  }
+}
+checks.push(new OptionalIfuseCommandCheck());
+
+
 export {
   fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
   AuthorizationDbCheck, CarthageCheck, OptionalFbsimctlCommandCheck, OptionalApplesimutilsCommandCheck, OptionalIdevicelocationCommandCheck,
-  OptionalIOSDeployCommandCheck, OptionalIOSWebkitDebugProxyCommandCheck
+  OptionalIOSDeployCommandCheck, OptionalIOSWebkitDebugProxyCommandCheck, OptionalIfuseCommandCheck
 };
 export default checks;

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -3,7 +3,7 @@
 import { fixes, XcodeCheck, XcodeCmdLineToolsCheck, DevToolsSecurityCheck,
          AuthorizationDbCheck, CarthageCheck, OptionalApplesimutilsCommandCheck,
          OptionalFbsimctlCommandCheck, OptionalIdevicelocationCommandCheck,
-         OptionalIOSDeployCommandCheck, OptionalIOSWebkitDebugProxyCommandCheck } from '../lib/ios';
+         OptionalIOSDeployCommandCheck, OptionalIOSWebkitDebugProxyCommandCheck, OptionalIfuseCommandCheck } from '../lib/ios';
 import { fs, system } from 'appium-support';
 import * as utils from '../lib/utils';
 import * as tp from 'teen_process';
@@ -414,6 +414,36 @@ describe('ios', function () {
     });
     it('fix', async function () {
       (await check.fix()).should.equal('ios_webkit_debug_proxy is used to proxy requets from Appium to MobileSafari running on real device. Please read https://github.com/google/ios-webkit-debug-proxy to install it');
+    });
+  }));
+
+  describe('OptionalIfuseCommandCheck', withMocks({tp, utils}, (mocks) => {
+    let check = new OptionalIfuseCommandCheck();
+    it('autofix', function () {
+      check.autofix.should.not.be.ok;
+    });
+    it('diagnose - success', async function () {
+      mocks.utils.expects('resolveExecutablePath').once().returns('path/to/ifuse');
+      mocks.tp.expects('exec').once().returns({stdout: ``, stderr: 'ifuse 1.1.3\n'});
+
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        optional: true,
+        message: 'ifuse is installed at: path/to/ifuse. Installed version is: 1.1.3'
+      });
+      mocks.verify();
+    });
+    it('diagnose - failure', async function () {
+      mocks.utils.expects('resolveExecutablePath').once().returns(false);
+      (await check.diagnose()).should.deep.equal({
+        ok: false,
+        optional: true,
+        message: 'ifuse cannot be found'
+      });
+      mocks.verify();
+    });
+    it('fix', async function () {
+      (await check.fix()).should.equal('ifuse is used to manage files/folders against a real device. Please run `brew cask install osxfuse && brew install ifuse --HEAD` or read https://github.com/libimobiledevice/ifuse to install it');
     });
   }));
 });

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -488,7 +488,7 @@ describe('ios', function () {
       mocks.verify();
     });
     it('fix', async function () {
-      (await check.fix()).should.equal('ifuse is used to manage files/folders against a real device. Please run `brew cask install osxfuse && brew install ifuse --HEAD` or read https://github.com/libimobiledevice/ifuse to install it');
+      (await check.fix()).should.equal('ifuse is used to manage files/folders against a real device. Please read https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/ios/ios-xctest-file-movement.md to install it');
     });
   }));
 });

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -424,12 +424,23 @@ describe('ios', function () {
     });
     it('diagnose - success', async function () {
       mocks.utils.expects('resolveExecutablePath').once().returns('path/to/ifuse');
-      mocks.tp.expects('exec').once().returns({stdout: ``, stderr: 'ifuse 1.1.3\n'});
+      mocks.tp.expects('exec').once().returns({stdout: '', stderr: 'ifuse 1.1.3\n'});
 
       (await check.diagnose()).should.deep.equal({
         ok: true,
         optional: true,
         message: 'ifuse is installed at: path/to/ifuse. Installed version is: 1.1.3'
+      });
+      mocks.verify();
+    });
+    it('diagnose - success - version is null', async function () {
+      mocks.utils.expects('resolveExecutablePath').once().returns('path/to/ifuse');
+      mocks.tp.expects('exec').once().returns({stdout: '', stderr: ''});
+
+      (await check.diagnose()).should.deep.equal({
+        ok: true,
+        optional: true,
+        message: 'ifuse is installed at: path/to/ifuse.'
       });
       mocks.verify();
     });


### PR DESCRIPTION
ifuse is used in file management against iOS real devices: https://github.com/appium/appium/issues/12283#issuecomment-497384996

```
info AppiumDoctor  ✔ ifuse is installed at: /usr/local/bin/ifuse. Installed version is: 1.1.3
```