### PR TITLE
fix syntax error with node 8.3.0

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -37,7 +37,7 @@ class NodeVersionCheck extends DoctorCheck {
       return util.compareVersions(REQUIRED_NODE_VERSION, '<=', versionString)
         ? ok(`Node version is ${versionString}`)
         : nok(`Node version should be at least ${REQUIRED_NODE_VERSION}!`);
-    } catch {
+    } catch (e) {
       return nok(`Unable to find node version (version = '${versionString}')`);
     }
   }


### PR DESCRIPTION
I run appium-doctor on my mac, get error.

/usr/local/lib/node_modules/appium-doctor/build/lib/general.js:59
    } catch {
            ^

SyntaxError: Unexpected token {
    at createScript (vm.js:74:10)
    at Object.runInThisContext (vm.js:116:10)
    at Module._compile (module.js:537:28)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/appium-doctor/lib/factory.js:3:1)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/appium-doctor/bin/appium-doctor.js:4:1)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
