### PR TITLE
Modified Messaging of `xcrun simctl`  to be more explicit

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -19,7 +19,10 @@ class XcodeCheck extends DoctorCheck {
     try {
       // https://github.com/appium/appium/issues/12093#issuecomment-459358120 can happen
       await exec('xcrun', ['simctl', 'help']);
-
+    } catch (err) {
+      return nok('Error running xcrun simctl');
+    }
+    try {
       const {stdout} = await exec('xcode-select', ['-p']);
       xcodePath = (stdout || '').replace('\n', '');
     } catch (err) {

--- a/test/ios-specs.js
+++ b/test/ios-specs.js
@@ -76,7 +76,7 @@ describe('ios', function () {
       (await check.diagnose()).should.deep.equal({
         ok: false,
         optional: false,
-        message: 'Xcode is NOT installed!'
+        message: 'Error running xcrun simctl'
       });
       mocks.verify();
     });


### PR DESCRIPTION
Modified Messaging of `xcrun simctl`  to be more explicit, so users can easily arrive at the message `xcrun: error: unable to find utility "simctl", not a developer tool or in PATH` and find the following solution to fix the issue.
https://stackoverflow.com/questions/29108172/xcrun-unable-to-find-simctl