### PR TITLE
Add logHandler callback as option to handle logs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ import log from '../lib/logger';
 import authorize from 'authorize-ios';
 import { fs, system } from 'appium-support';
 import { exec } from 'teen_process';
+import { isFunction } from 'lodash';
 
 // rename to make more sense
 const authorizeIos = authorize;
@@ -29,6 +30,10 @@ function configureBinaryLog (opts) {
     let l = this.levels[level];
     if (l < this.levels[this.level]) return; // eslint-disable-line curly
     actualLog(level, prefix, msg);
+
+    if (isFunction(opts.onLogMessage)) {
+      opts.onLogMessage(level, prefix, msg);
+    }
   };
   log.level = opts.debug ? 'debug' : 'info';
 }

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -1,9 +1,10 @@
 // transpile:mocha
 
-import { pkgRoot } from '../lib/utils';
+import { pkgRoot, configureBinaryLog } from '../lib/utils';
 import { fs } from 'appium-support';
 import chai from 'chai';
 import path from 'path';
+import { Doctor } from '../lib/doctor';
 
 chai.should();
 
@@ -19,6 +20,16 @@ describe('utils', function () {
       'wow.txt'))).should.be.ok;
     (await fs.exists(path.resolve(pkgRoot, 'test', 'fixtures',
       'notwow.txt'))).should.not.be.ok;
+  });
+
+  it('Should handle logs through onLogMessage callback', function () {
+    function onLogMessage (level, prefix, msg) {
+      `${level} ${prefix} ${msg}`.should.include('AppiumDoctor');
+    }
+
+    configureBinaryLog({ onLogMessage });
+    let doctor = new Doctor();
+    doctor.run();
   });
 
 });


### PR DESCRIPTION
**Description:**

When I use appium-doctor in the NodeJS project (not as CLI), I couldn't handle logs without add callback function.

**Usage:**

```
function onLogMessage (level, prefix, msg) {
    console.log(level);
    console.log(prefix);
    console.log(msg);
}

configureBinaryLog({ onLogMessage });
```

**Detail Usage in Project:**

```
import { system } from 'appium-support';
import { newDoctor } from 'appium-doctor/build';
import { configureBinaryLog } from 'appium-doctor/build/lib/utils';
import { configure as configurePrompt } from 'appium-doctor/build/lib/prompt';

(()=> {
    function onLogMessage (level, prefix, msg) {
        console.log('DEBUG level', level);
        console.log('DEBUG prefix', prefix);
        console.log('DEBUG prefix', prefix);
    }

    const opts = {
        general: true,
        ios: system.isMac(),
        android: true,
        onLogMessage,
    };

    configurePrompt(opts);
    configureBinaryLog(opts);
    const doctor = newDoctor(opts);

    doctor.run().then(() => {
        console.log('DEBUG doctor.toFix', doctor.toFix);
        console.log('DEBUG doctor.toFixOptionals', doctor.toFixOptionals);
    });
})();
```