### PR TITLE
feat: add urls to sdkmanager for emulator/android installation

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -50,7 +50,8 @@ class AndroidToolCheck extends DoctorCheck {
     if (typeof process.env.ANDROID_HOME === 'undefined') {
       return `Manually configure ${'ANDROID_HOME'.bold} and run appium-doctor again.`;
     }
-    return `Manually install ${this.toolName.bold} and add it to ${'PATH'.bold}.`;
+
+    return `Manually install ${this.toolName.bold} and add it to ${'PATH'.bold}. https://developer.android.com/studio#cmdline-tools and https://developer.android.com/studio/intro/update#sdk-manager may help to setup.`;
   }
 }
 checks.push(new AndroidToolCheck('adb',

--- a/lib/android.js
+++ b/lib/android.js
@@ -51,7 +51,9 @@ class AndroidToolCheck extends DoctorCheck {
       return `Manually configure ${'ANDROID_HOME'.bold} and run appium-doctor again.`;
     }
 
-    return `Manually install ${this.toolName.bold} and add it to ${'PATH'.bold}. https://developer.android.com/studio#cmdline-tools and https://developer.android.com/studio/intro/update#sdk-manager may help to setup.`;
+    return `Manually install ${this.toolName.bold} and add it to ${'PATH'.bold}. ` +
+      'https://developer.android.com/studio#cmdline-tools and ' +
+      'https://developer.android.com/studio/intro/update#sdk-manager may help to setup.';
   }
 }
 checks.push(new AndroidToolCheck('adb',

--- a/test/android-specs.js
+++ b/test/android-specs.js
@@ -94,7 +94,9 @@ describe('android', function () {
     });
     it('fix - install', async function () {
       process.env.ANDROID_HOME = '/a/b/c/d';
-      removeColors(await check.fix()).should.equal('Manually install adb and add it to PATH. https://developer.android.com/studio#cmdline-tools and https://developer.android.com/studio/intro/update#sdk-manager may help to setup.');
+      removeColors(await check.fix()).should.equal('Manually install adb and add it to PATH. ' +
+        'https://developer.android.com/studio#cmdline-tools and ' +
+        'https://developer.android.com/studio/intro/update#sdk-manager may help to setup.');
     });
   }));
 

--- a/test/android-specs.js
+++ b/test/android-specs.js
@@ -94,7 +94,7 @@ describe('android', function () {
     });
     it('fix - install', async function () {
       process.env.ANDROID_HOME = '/a/b/c/d';
-      removeColors(await check.fix()).should.equal('Manually install adb and add it to PATH.');
+      removeColors(await check.fix()).should.equal('Manually install adb and add it to PATH. https://developer.android.com/studio#cmdline-tools and https://developer.android.com/studio/intro/update#sdk-manager may help to setup.');
     });
   }));
 


### PR DESCRIPTION
It is helpful to guide users to sdkmanager since newer AS recommend to use them.
closes https://github.com/appium/appium/issues/14144