### PR TITLE
chore: refer to the same path to Android binaries

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -4,7 +4,7 @@ import { system } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
 import 'colors';
-import { getAndroidBinaryPath } from 'appium-adb';
+import { getAndroidBinaryPath, getSdkRootFromEnv } from 'appium-adb';
 import log from './logger';
 
 let checks = [];
@@ -35,30 +35,29 @@ class JavaOnPathCheck extends DoctorCheck {
 class AndroidToolCheck extends DoctorCheck {
   constructor () {
     super();
-    this.tools = ['adb', 'android', 'emulator', 'apkanalyzer'];
+    this.tools = ['adb', 'android', 'emulator'];
+    this.noBinaries = [];
   }
 
   async diagnose () {
     const listOfTools = this.tools.join(', ');
-    const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+    const sdkRoot = getSdkRootFromEnv();
     if (!sdkRoot) {
       return nok(`${listOfTools} could not be found because ANDROID_HOME or ANDROID_SDK_ROOT is NOT set!`);
     }
 
     log.info(`   Checking ${listOfTools}`);
 
-    const noBinaries = [];
     for (const binary of this.tools) {
       try {
         log.info(`     '${binary}' is in ${await getAndroidBinaryPath(binary)}`);
       } catch (e) {
-        // TODO: Print error messages
-        noBinaries.push(binary);
+        this.noBinaries.push(binary);
       }
     }
 
-    if (noBinaries.length > 0) {
-      return nok(`${noBinaries.join(', ')} could NOT be found in ${sdkRoot}!`);
+    if (this.noBinaries.length > 0) {
+      return nok(`${this.noBinaries.join(', ')} could NOT be found in ${sdkRoot}!`);
     }
 
     return ok(`${listOfTools} exist: ${sdkRoot}`);
@@ -69,7 +68,7 @@ class AndroidToolCheck extends DoctorCheck {
       return `Manually configure ${'ANDROID_HOME'.bold} and run appium-doctor again.`;
     }
 
-    return `Manually install ${this.toolName.bold} and add it to ${'PATH'.bold}. ` +
+    return `Manually install ${this.noBinaries.join(', ').bold} and add it to ${'PATH'.bold}. ` +
       'https://developer.android.com/studio#cmdline-tools and ' +
       'https://developer.android.com/studio/intro/update#sdk-manager may help to setup.';
   }

--- a/lib/android.js
+++ b/lib/android.js
@@ -1,10 +1,11 @@
 import { DoctorCheck } from './doctor';
 import { ok, nok, okOptional, nokOptional, resolveExecutablePath } from './utils';
-import { fs, system } from 'appium-support';
+import { system } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
 import 'colors';
-import { ADB } from 'appium-adb';
+import { getAndroidBinaryPath } from 'appium-adb';
+import log from './logger';
 
 let checks = [];
 
@@ -34,30 +35,33 @@ class JavaOnPathCheck extends DoctorCheck {
 class AndroidToolCheck extends DoctorCheck {
   constructor () {
     super();
-    this.tools = ['adb', 'android', 'emulator'];
+    this.tools = ['adb', 'android', 'emulator', 'apkanalyzer'];
   }
 
   async diagnose () {
-    if (typeof process.env.ANDROID_HOME === 'undefined') {
-      return nok(`${this.tools.join(', ')} could not be found because ANDROID_HOME is NOT set!`);
+    const listOfTools = this.tools.join(', ');
+    const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+    if (!sdkRoot) {
+      return nok(`${listOfTools} could not be found because ANDROID_HOME or ANDROID_SDK_ROOT is NOT set!`);
     }
 
-    // TODO: Prevent printing logs
-    const adb = await ADB.createADB();
-    const no = [];
+    log.info(`   Checking ${listOfTools}`);
+
+    const noBinaries = [];
     for (const binary of this.tools) {
       try {
-          await adb.getBinaryFromSdkRoot(binary);
-      } catch {
-        no.push(binary);
-      };
-    };
-
-    if (no.length > 0) {
-      return nok(`${no.join(', ')} could NOT be found!`);
+        log.info(`     '${binary}' is in ${await getAndroidBinaryPath(binary)}`);
+      } catch (e) {
+        // TODO: Print error messages
+        noBinaries.push(binary);
+      }
     }
 
-    return ok(`${this.tools.join(', ')} exist in: ${process.env.ANDROID_HOME}`);
+    if (noBinaries.length > 0) {
+      return nok(`${noBinaries.join(', ')} could NOT be found in ${sdkRoot}!`);
+    }
+
+    return ok(`${listOfTools} exist: ${sdkRoot}`);
   }
 
   fix () {

--- a/lib/android.js
+++ b/lib/android.js
@@ -4,6 +4,7 @@ import { fs, system } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
 import 'colors';
+import { ADB } from 'appium-adb';
 
 let checks = [];
 
@@ -31,19 +32,32 @@ class JavaOnPathCheck extends DoctorCheck {
 
 // Check tools
 class AndroidToolCheck extends DoctorCheck {
-  constructor (toolName, toolPath) {
+  constructor () {
     super();
-    this.toolName = toolName;
-    this.toolPath = toolPath;
+    this.tools = ['adb', 'android', 'emulator'];
   }
 
   async diagnose () {
     if (typeof process.env.ANDROID_HOME === 'undefined') {
-      return nok(`${this.toolName} could not be found because ANDROID_HOME is NOT set!`);
+      return nok(`${this.tools.join(', ')} could not be found because ANDROID_HOME is NOT set!`);
     }
-    let fullPath = path.resolve(process.env.ANDROID_HOME, this.toolPath);
-    return await fs.exists(fullPath) ? ok(`${this.toolName} exists at: ${fullPath}`) :
-      nok(`${this.toolName} could NOT be found at '${fullPath}'!`);
+
+    // TODO: Prevent printing logs
+    const adb = await ADB.createADB();
+    const no = [];
+    for (const binary of this.tools) {
+      try {
+          await adb.getBinaryFromSdkRoot(binary);
+      } catch {
+        no.push(binary);
+      };
+    };
+
+    if (no.length > 0) {
+      return nok(`${no.join(', ')} could NOT be found!`);
+    }
+
+    return ok(`${this.tools.join(', ')} exist in: ${process.env.ANDROID_HOME}`);
   }
 
   fix () {
@@ -56,12 +70,7 @@ class AndroidToolCheck extends DoctorCheck {
       'https://developer.android.com/studio/intro/update#sdk-manager may help to setup.';
   }
 }
-checks.push(new AndroidToolCheck('adb',
-  path.join('platform-tools', system.isWindows() ? 'adb.exe' : 'adb')));
-checks.push(new AndroidToolCheck('android',
-  path.join('tools', system.isWindows() ? 'android.bat' : 'android')));
-checks.push(new AndroidToolCheck('emulator',
-  path.join('tools', system.isWindows() ? 'emulator.exe' : 'emulator')));
+checks.push(new AndroidToolCheck());
 checks.push(new JavaOnPathCheck());
 
 class OptionalAppBundleCheck extends DoctorCheck {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
-    "appium-adb": "^8.3.0",
+    "appium-adb": "^8.4.0",
     "authorize-ios": "^1.0.3",
     "bluebird": "^3.5.1",
     "colors": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
+    "appium-adb": "^8.1.0",
     "authorize-ios": "^1.0.3",
     "bluebird": "^3.5.1",
     "colors": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
-    "appium-adb": "^8.1.0",
+    "appium-adb": "^8.3.0",
     "authorize-ios": "^1.0.3",
     "bluebird": "^3.5.1",
     "colors": "^1.1.2",

--- a/test/android-specs.js
+++ b/test/android-specs.js
@@ -2,6 +2,7 @@
 
 import { EnvVarAndPathCheck, AndroidToolCheck, OptionalAppBundleCheck, OptionalGstreamerCheck } from '../lib/android';
 import { fs } from 'appium-support';
+import * as adb from 'appium-adb';
 import * as utils from '../lib/utils';
 import * as tp from 'teen_process';
 import chai from 'chai';
@@ -52,19 +53,19 @@ describe('android', function () {
       removeColors(await check.fix()).should.equal('Manually configure ANDROID_HOME.');
     });
   }));
-  describe('AndroidToolCheck', withMocks({fs}, (mocks) => {
+  describe('AndroidToolCheck', withMocks({adb}, (mocks) => {
     stubEnv();
-    let check = new AndroidToolCheck('adb', 'platform-tools/adb');
+    let check = new AndroidToolCheck();
     it('autofix', function () {
       check.autofix.should.not.be.ok;
     });
     it('diagnose - success', async function () {
       process.env.ANDROID_HOME = '/a/b/c/d';
-      mocks.fs.expects('exists').once().returns(B.resolve(true));
+      mocks.adb.expects('getAndroidBinaryPath').exactly(3).returns(B.resolve('/path/to/binary'));
       (await check.diagnose()).should.deep.equal({
         ok: true,
         optional: false,
-        message: 'adb exists at: /a/b/c/d/platform-tools/adb'
+        message: 'adb, android, emulator exist: /a/b/c/d'
       });
       mocks.verify();
     });
@@ -73,17 +74,17 @@ describe('android', function () {
       (await check.diagnose()).should.deep.equal({
         ok: false,
         optional: false,
-        message: 'adb could not be found because ANDROID_HOME is NOT set!'
+        message: 'adb, android, emulator could not be found because ANDROID_HOME or ANDROID_SDK_ROOT is NOT set!'
       });
       mocks.verify();
     });
     it('diagnose - failure - path not valid', async function () {
       process.env.ANDROID_HOME = '/a/b/c/d';
-      mocks.fs.expects('exists').once().returns(B.resolve(false));
+      mocks.adb.expects('getAndroidBinaryPath').exactly(3).throws();
       (await check.diagnose()).should.deep.equal({
         ok: false,
         optional: false,
-        message: 'adb could NOT be found at \'/a/b/c/d/platform-tools/adb\'!'
+        message: 'adb, android, emulator could NOT be found in /a/b/c/d!'
       });
       mocks.verify();
     });
@@ -94,7 +95,7 @@ describe('android', function () {
     });
     it('fix - install', async function () {
       process.env.ANDROID_HOME = '/a/b/c/d';
-      removeColors(await check.fix()).should.equal('Manually install adb and add it to PATH. ' +
+      removeColors(await check.fix()).should.equal('Manually install adb, android, emulator and add it to PATH. ' +
         'https://developer.android.com/studio#cmdline-tools and ' +
         'https://developer.android.com/studio/intro/update#sdk-manager may help to setup.');
     });

--- a/test/android-specs.js
+++ b/test/android-specs.js
@@ -55,7 +55,7 @@ describe('android', function () {
   }));
   describe('AndroidToolCheck', withMocks({adb}, (mocks) => {
     stubEnv();
-    let check = new AndroidToolCheck();
+    const check = new AndroidToolCheck();
     it('autofix', function () {
       check.autofix.should.not.be.ok;
     });


### PR DESCRIPTION
I'm thinking to refer to the same method of appium-adb to check binaries existence to make the differences small
e,g, When we get a situation like https://github.com/appium/appium-adb/pull/529 , we won't change the same thing for both appium-adb and this repository

---

Not finished yet.
Need to control log messages (and fix tests)