### PR TITLE
chore: Update JAVA_HOME validation

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -24,7 +24,7 @@ class JavaOnPathCheck extends DoctorCheck {
         : nok(`'bin' subfolder does not exist under '${process.env.JAVA_HOME}'. ` +
               `Is ${javaHome} set to a proper value?`);
     }
-    return nok(`Cannot check ${javaHome} requirements since the environment variable itself is not set`);;
+    return nok(`Cannot check ${javaHome} requirements since the environment variable itself is not set`);
   }
 
   fix () {

--- a/lib/android.js
+++ b/lib/android.js
@@ -24,11 +24,11 @@ class JavaOnPathCheck extends DoctorCheck {
         : nok(`'bin' subfolder does not exist under '${process.env.JAVA_HOME}'. ` +
               `Is ${javaHome} set to a proper value?`);
     }
-    return nok(`Cannot check ${javaHome} requirements since the env variable is not set`);;
+    return nok(`Cannot check ${javaHome} requirements since the environment variable itself is not set`);;
   }
 
   fix () {
-    return `Set ${javaHome} environment variable to the root path of your local JDK installation`;
+    return `Set ${javaHome} environment variable to the root folder path of your local JDK installation`;
   }
 }
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -1,6 +1,6 @@
 import { DoctorCheck } from './doctor';
 import { ok, nok, okOptional, nokOptional, resolveExecutablePath } from './utils';
-import { system } from 'appium-support';
+import { system, fs } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
 import 'colors';
@@ -9,25 +9,26 @@ import log from './logger';
 
 let checks = [];
 
-let javaHome = system.isWindows() ? '%JAVA_HOME%' : '$JAVA_HOME';
+const javaHome = system.isWindows() ? '%JAVA_HOME%' : '$JAVA_HOME';
 
 checks.push(new EnvVarAndPathCheck('ANDROID_HOME'));
 checks.push(new EnvVarAndPathCheck('JAVA_HOME'));
 
 // Check that the PATH includes the jdk's bin directory
 class JavaOnPathCheck extends DoctorCheck {
-  async diagnose () { // eslint-disable-line require-await
+  async diagnose () {
     if (process.env.JAVA_HOME) {
-      let javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
-      if (process.env.PATH.indexOf(javaHomeBin) + 1) {
-        return ok(`Bin directory of ${javaHome} is set`);
-      }
+      const javaHomeBin = path.resolve(process.env.JAVA_HOME, 'bin');
+      return await fs.exists(javaHomeBin)
+        ? ok(`'bin' subfolder exists under '${process.env.JAVA_HOME}'`)
+        : nok(`'bin' subfolder does not exist under '${process.env.JAVA_HOME}'. ` +
+              `Is ${javaHome} set to a proper value?`);
     }
-    return nok(`Bin directory for ${javaHome} is not set`);
+    return nok(`Cannot check ${javaHome} requirements since the env variable is not set`);;
   }
 
   fix () {
-    return `Add ${`'${javaHome}${path.sep}bin'`.bold} to your ${'PATH'.bold} environment`;
+    return `Set ${javaHome} environment variable to the root path of your local JDK installation`;
   }
 }
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -13,14 +13,15 @@ class EnvVarAndPathCheck extends DoctorCheck {
   async diagnose () {
     let varValue = process.env[this.varName];
     if (typeof varValue === 'undefined') {
-      return nok(`${this.varName} is NOT set!`);
+      return nok(`${this.varName} environment variable is NOT set!`);
     }
     return await fs.exists(varValue) ? ok(`${this.varName} is set to: ${varValue}`) :
       nok(`${this.varName} is set to '${varValue}' but this is NOT a valid path!`);
   }
 
   fix () {
-    return `Manually configure ${this.varName.bold}.`;
+    return `Make sure the environment variable ${this.varName.bold} is properly configured for the Appium process. ` +
+      `Refer https://github.com/appium/java-client/blob/master/docs/environment.md for more details.`;
   }
 }
 

--- a/test/android-specs.js
+++ b/test/android-specs.js
@@ -31,11 +31,10 @@ describe('android', function () {
     });
     it('failure - not set', async function () {
       delete process.env.ANDROID_HOME;
-      (await check.diagnose()).should.deep.equal({
-        ok: false,
-        optional: false,
-        message: 'ANDROID_HOME is NOT set!'
-      });
+      const {ok, optional, message} = await check.diagnose();
+      ok.should.be.false;
+      optional.should.be.false;
+      message.should.not.be.empty;
       mocks.verify();
     });
     it('failure - file not exists', async function () {
@@ -50,7 +49,7 @@ describe('android', function () {
       mocks.verify();
     });
     it('fix', async function () {
-      removeColors(await check.fix()).should.equal('Manually configure ANDROID_HOME.');
+      removeColors(await check.fix()).should.contain('ANDROID_HOME');
     });
   }));
   describe('AndroidToolCheck', withMocks({adb}, (mocks) => {


### PR DESCRIPTION
The current message is a bit cryptic for users. Also, We don't actually need the presence of the value in PATH, because appium-adb anyway uses JAVA_HOME to figure out path to JDK-specific binaries