### PR TITLE
fix: Switch colors to a non-compomised repository

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -3,7 +3,7 @@ import { ok, nok, okOptional, nokOptional, resolveExecutablePath } from './utils
 import { system, fs } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
-import 'colors';
+import '@dabh/colors';
 import { getAndroidBinaryPath, getSdkRootFromEnv } from 'appium-adb';
 import log from './logger';
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -2,7 +2,7 @@ import { DoctorCheck } from './doctor';
 import { ok, nok, resolveExecutablePath } from './utils';
 import { fs, system } from 'appium-support';
 import path from 'path';
-import 'colors';
+import '@dabh/colors';
 
 let checks = [];
 

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,4 +1,4 @@
-import 'colors';
+import '@dabh/colors';
 import _ from 'lodash';
 import log from './logger';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,7 +1,7 @@
 import { fs } from 'appium-support';
 import { DoctorCheck } from './doctor';
 import { ok, nok } from './utils';
-import 'colors';
+import '@dabh/colors';
 
 // Check env variables
 class EnvVarAndPathCheck extends DoctorCheck {

--- a/lib/general.js
+++ b/lib/general.js
@@ -4,7 +4,7 @@ import { DoctorCheck } from './doctor';
 import NodeDetector from './node-detector';
 import { util } from 'appium-support';
 import { EOL } from 'os';
-import 'co@dabh/colorslors';
+import '@dabh/colors';
 
 let checks = [];
 

--- a/lib/general.js
+++ b/lib/general.js
@@ -4,7 +4,7 @@ import { DoctorCheck } from './doctor';
 import NodeDetector from './node-detector';
 import { util } from 'appium-support';
 import { EOL } from 'os';
-import 'colors';
+import 'co@dabh/colorslors';
 
 let checks = [];
 

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -7,7 +7,7 @@ import CarthageDetector from './carthage-detector';
 import { fixIt } from './prompt';
 import EnvVarAndPathCheck from './env';
 import _ from 'lodash';
-import 'colors';
+import '@dabh/colors';
 
 let checks = [];
 let fixes = {};

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "@dabh/colors": "^1.4.0",
     "appium-support": "^2.5.0",
     "appium-adb": "^8.4.0",
     "authorize-ios": "^1.0.3",
     "bluebird": "^3.5.1",
-    "colors": "^1.1.2",
     "inquirer": "^7.0.0",
     "lodash": "^4.17.10",
     "source-map-support": "^0.5.6",


### PR DESCRIPTION
This PR switches colors dependency to a non-compomised repository.

Related to Marak/colors.js#285