### PR TITLE
chore(docs): fix broken link for opencv4nodejs

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -60,7 +60,7 @@ class OptionalOpencv4nodejsCommandCheck extends DoctorCheck {
   }
 
   async fix () { // eslint-disable-line require-await
-    return `Why ${'opencv4nodejs'.bold} is needed and how to install it: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/image-comparison.md`;
+    return `Why ${'opencv4nodejs'.bold} is needed and how to install it: http://appium.io/docs/en/writing-running-appium/image-comparison/`;
   }
 }
 checks.push(new OptionalOpencv4nodejsCommandCheck());

--- a/test/general-specs.js
+++ b/test/general-specs.js
@@ -119,7 +119,7 @@ describe('general', function () {
     });
     it('fix', async function () {
       removeColors(await check.fix()).should.
-        equal('Why opencv4nodejs is needed and how to install it: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/image-comparison.md');
+        equal('Why opencv4nodejs is needed and how to install it: http://appium.io/docs/en/writing-running-appium/image-comparison/');
     });
   }));
 


### PR DESCRIPTION
👋  there

I was just following the guide here http://appium.io/docs/en/about-appium/getting-started/, I tried running the doctor for android to see if my machine was correctly setup and since I don't have opencv4nodejs installed it showed it in the optional fixes; the issue is that the copy points to https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/image-comparison.md which is a broken link.

I scouted around the repo and it looks like there's this https://github.com/appium/appium/blob/master/packages/images-plugin/docs/image-comparison.md but it looks more like it's actually meant to target this page http://appium.io/docs/en/writing-running-appium/image-comparison/ so I changed the url.

I hope that's ok,
cheers ✌️