### PR TITLE
chore: add deprecated log to use @appium/doctor

### DIFF
--- a/bin/appium-doctor.js
+++ b/bin/appium-doctor.js
@@ -6,7 +6,6 @@ import { configureBinaryLog } from '../lib/utils';
 import { configure as configurePrompt } from '../lib/prompt';
 import { system } from 'appium-support';
 
-
 yargs
   .strict()
   .usage('Usage: $0 [options, defaults: --ios --android]')

--- a/lib/android.js
+++ b/lib/android.js
@@ -3,7 +3,7 @@ import { ok, nok, okOptional, nokOptional, resolveExecutablePath } from './utils
 import { system, fs } from 'appium-support';
 import path from 'path';
 import EnvVarAndPathCheck from './env';
-import '@dabh/colors';
+import '@colors/colors';
 import { getAndroidBinaryPath, getSdkRootFromEnv } from 'appium-adb';
 import log from './logger';
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -2,7 +2,7 @@ import { DoctorCheck } from './doctor';
 import { ok, nok, resolveExecutablePath } from './utils';
 import { fs, system } from 'appium-support';
 import path from 'path';
-import '@dabh/colors';
+import '@colors/colors';
 
 let checks = [];
 

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,4 +1,4 @@
-import '@dabh/colors';
+import '@colors/colors';
 import _ from 'lodash';
 import log from './logger';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
@@ -140,6 +140,7 @@ class Doctor {
   }
 
   async run () {
+    log.warn('[Deprecated] Please use appium-doctor installed with "npm install @appium/doctor -g"');
     log.info(`Appium Doctor v.${version}`);
     await this.diagnose();
     if (await this.reportSuccess(this.toFix.length, this.toFixOptionals.length)) {

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -140,7 +140,7 @@ class Doctor {
   }
 
   async run () {
-    log.warn('[Deprecated] Please use appium-doctor installed with "npm install @appium/doctor -g"');
+    log.warn('[Deprecated] Please use appium-doctor installed with "npm install @appium/doctor --location=global"');
     log.info(`Appium Doctor v.${version}`);
     await this.diagnose();
     if (await this.reportSuccess(this.toFix.length, this.toFixOptionals.length)) {

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,7 +1,7 @@
 import { fs } from 'appium-support';
 import { DoctorCheck } from './doctor';
 import { ok, nok } from './utils';
-import '@dabh/colors';
+import '@colors/colors';
 
 // Check env variables
 class EnvVarAndPathCheck extends DoctorCheck {

--- a/lib/general.js
+++ b/lib/general.js
@@ -4,7 +4,7 @@ import { DoctorCheck } from './doctor';
 import NodeDetector from './node-detector';
 import { util } from 'appium-support';
 import { EOL } from 'os';
-import '@dabh/colors';
+import '@colors/colors';
 
 let checks = [];
 

--- a/lib/ios.js
+++ b/lib/ios.js
@@ -7,7 +7,7 @@ import CarthageDetector from './carthage-detector';
 import { fixIt } from './prompt';
 import EnvVarAndPathCheck from './env';
 import _ from 'lodash';
-import '@dabh/colors';
+import '@colors/colors';
 
 let checks = [];
 let fixes = {};

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@dabh/colors": "^1.4.0",
+    "@colors/colors": "^1.5.0",
     "appium-support": "^2.5.0",
     "appium-adb": "^8.4.0",
     "authorize-ios": "^1.0.3",


### PR DESCRIPTION
I think we should release a new doctor package available via `npm install appium-doctor -g` to guid users to the new `@appium/doctor` one for the future `appium-doctor`